### PR TITLE
Add more overloads of WriteTableCell

### DIFF
--- a/Anixe.Ion.UnitTests/IonWriterTests.cs
+++ b/Anixe.Ion.UnitTests/IonWriterTests.cs
@@ -228,8 +228,8 @@ namespace Anixe.Ion.UnitTests
             {
                 subject.WriteTableCell((tw) => tw.Write("unit_type"));
                 subject.WriteTableCell((tw) => tw.Write("miles"), true);
-                subject.WriteTableCell((tw) => tw.Write("unit_type"));
-                subject.WriteTableCell((tw) => tw.Write("miles"), true);
+                subject.WriteTableCell("unit_type");
+                subject.WriteTableCell("miles", true);
                 Assert.AreEqual(WriterState.TableRow, subject.State);
                 subject.WriteEmptyLine();
                 Assert.AreEqual(WriterState.None, subject.State);
@@ -239,13 +239,12 @@ namespace Anixe.Ion.UnitTests
             CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
         }
 
-
         [Test]
         public void Should_Write_Tables()
         {
             var row = new string[] { "unit_type", "miles" };
             var row2 = new string[] { "unit_type", "miles", "23" };
-            var expected = new string[] 
+            var expected = new string[]
             {
                 "[DATA]",
                 string.Empty,
@@ -277,8 +276,8 @@ namespace Anixe.Ion.UnitTests
         {
             var header = new string[] { "key", "val" };
             var row = new string[] { "unit_type", "miles" };
-      var expected = new string[]
-      {
+            var expected = new string[]
+            {
                 "[DATA]",
                 "| key | val |",
                 "|-----|-----|",

--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
   </PropertyGroup>
 
 </Project>

--- a/Anixe.Ion/IonWriter.cs
+++ b/Anixe.Ion/IonWriter.cs
@@ -208,26 +208,86 @@ namespace Anixe.Ion
         public void WriteTableCell(Action<TextWriter> writeCellAction, bool lastCellInRow = false)
         {
             ValidateWriteTableCell(writeCellAction);
-            if(this.firstTableCell)
+            WriteTableCellBefore();
+            writeCellAction(this.tw);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(int value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(string value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(double value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+
+        public void WriteTableCell(decimal value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(long value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(bool value, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(value);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        public void WriteTableCell(char[] buffer, int index, int count, bool lastCellInRow = false)
+        {
+            WriteTableCellBefore();
+            tw.Write(buffer, index, count);
+            WriteTableCellAfter(lastCellInRow);
+        }
+
+        private void WriteTableCellBefore()
+        {
+            if (this.firstTableCell)
             {
-                tw.Write(Consts.IonSpecialChars.TableOpeningCharacter);
-                this.firstTableCell = false;
+              tw.Write(Consts.IonSpecialChars.TableOpeningCharacter);
+              this.firstTableCell = false;
             }
             tw.Write(Consts.IonSpecialChars.WriteSpaceCharacter);
-            writeCellAction(this.tw);
+        }
+
+        private void WriteTableCellAfter(bool lastCellInRow = false)
+        {
             tw.Write(Consts.IonSpecialChars.WriteSpaceCharacter);
             tw.Write(Consts.IonSpecialChars.TableOpeningCharacter);
-            if(lastCellInRow)
+            if (lastCellInRow)
             {
-                this.tw.WriteLine();
-                this.firstTableCell = true;
+              this.tw.WriteLine();
+              this.firstTableCell = true;
             }
             this.state &= ~WriterState.Property;
             this.state &= ~WriterState.TableHeader;
             this.state |= WriterState.TableRow;
-        }
+    }
 
-        private void ValidateWriteTableCell(Action<TextWriter> writeCellAction)
+    private void ValidateWriteTableCell(Action<TextWriter> writeCellAction)
         {
             if(writeCellAction == null)
             {


### PR DESCRIPTION
Until now there was only option to pass `Action<TextWriter>`. The actions took data from outer scope, so there was created lots of lambda classes in run-time.
Example:
```csharp
string text = "some_text";
ionWriter.Write(tw => tw.Write(text)); //run-time produces new class to pass text to the lambda 
ionWriter.Write(text); //there is no lambda, so it's more performant
```