### PR TITLE
Use pooling of IonReader buffers

### DIFF
--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>2.0.10</Version>
+    <Version>2.0.11</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
IonReaderBenchmark before:
```
 Method |     Mean |     Error |    StdDev |   Median | Allocated |
------- |---------:|----------:|----------:|---------:|----------:|
   Read | 13.82 ms | 0.2852 ms | 0.8319 ms | 13.57 ms |  14.88 KB |
```

IonReaderBenchmark after:
```
 Method |     Mean |     Error |    StdDev | Allocated |
------- |---------:|----------:|----------:|----------:|
   Read | 13.04 ms | 0.2566 ms | 0.2635 ms |   7.83 KB |
```