### PR TITLE
Improve null analysis for IonReader.CurrentSection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET 6.0
+    - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
+++ b/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
+++ b/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Version>2.1.2</Version>
     <LangVersion>latest</LangVersion>

--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Anixe.Ion/Helpers/BufferWriter.cs
+++ b/Anixe.Ion/Helpers/BufferWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Anixe.Ion.Helpers
 {
@@ -15,7 +16,7 @@ namespace Anixe.Ion.Helpers
 #else
             ? ArraySegment<char>.Empty
 #endif
-            : new ArraySegment<char>(this.buffer, 0, this.Count);
+            : new ArraySegment<char>(this.buffer ?? Array.Empty<char>(), 0, this.Count);
 
         public BufferWriter(ArrayPool<char> pool)
         {
@@ -31,6 +32,9 @@ namespace Anixe.Ion.Helpers
           this.Count += charCount;
         }
 
+#if NET6_0_OR_GREATER
+        [MemberNotNull(nameof(this.buffer))]
+#endif
         private void EnsureCapacity(int length)
         {
             if (this.buffer != null)

--- a/Anixe.Ion/Helpers/ThrowHelper.cs
+++ b/Anixe.Ion/Helpers/ThrowHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Anixe.Ion.Exceptions;
+using System;
 #if !NETSTANDARD2_0
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -13,6 +14,14 @@ namespace Anixe.Ion.Helpers
         public static void Throw_InvalidTableCellDataException()
         {
             throw new InvalidTableCellDataException("Table cell contains prohibited character");
+        }
+
+#if !NETSTANDARD2_0
+        [DoesNotReturn]
+#endif
+        public static void Throw_ArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
         }
     }
 }

--- a/Anixe.Ion/IIonReader.cs
+++ b/Anixe.Ion/IIonReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Anixe.Ion
 {
@@ -11,6 +12,9 @@ namespace Anixe.Ion
         /// Gets a value indicating whether this instance of <see cref="IIonReader"/> is currently on section header.
         /// </summary>
         /// <value><see langword="true"/> if <see cref="IIonReader.CurrentLine"/> first character is equal to '['; otherwise, <see langword="false"/>.</value>
+#if NET6_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(CurrentSection))]
+#endif
         bool IsSectionHeader { get; }
 
         /// <summary>

--- a/Anixe.Ion/IonReader.cs
+++ b/Anixe.Ion/IonReader.cs
@@ -1,6 +1,7 @@
 ﻿using Anixe.Ion.Helpers;
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -51,6 +52,9 @@ namespace Anixe.Ion
 
         #region IIonReader members
 
+#if NET6_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(CurrentSection))]
+#endif
         public bool IsSectionHeader => this.currentLineVerifier.IsSectionHeader(CurrentRawLine);
 
         public bool IsProperty => this.currentLineVerifier.IsProperty(CurrentRawLine);
@@ -67,7 +71,7 @@ namespace Anixe.Ion
 
         public bool IsEmptyLine => this.currentLineVerifier.IsEmptyLine(CurrentRawLine);
 
-        public string CurrentLine => new string(CurrentRawLine.Array, CurrentRawLine.Offset, CurrentRawLine.Count);
+        public string CurrentLine => new string(CurrentRawLine.Array!, CurrentRawLine.Offset, CurrentRawLine.Count);
 
         public ArraySegment<char> CurrentRawLine { get; private set; }
 
@@ -105,7 +109,7 @@ namespace Anixe.Ion
             if(IsSectionHeader)
             {
                 ArraySegment<char> headerSegment = this.sectionHeaderReader.Read(CurrentRawLine);
-                CurrentSection = new string(headerSegment.Array, headerSegment.Offset, headerSegment.Count);
+                CurrentSection = new string(headerSegment.Array!, headerSegment.Offset, headerSegment.Count);
             }
 
             if(passedCurrentTableHeaderRow)

--- a/Anixe.Ion/IonWriter.cs
+++ b/Anixe.Ion/IonWriter.cs
@@ -275,11 +275,16 @@ namespace Anixe.Ion
 
         public void WriteTableCell(char[] buffer, int index, int count, bool lastCellInRow = false)
         {
-            WriteTableCellBefore();
-            if (buffer != null)
+            if (buffer == null)
             {
-                Validate(buffer, index, count);
+                ThrowHelper.Throw_ArgumentNullException(nameof(buffer));
+#if NETSTANDARD2_0
+                return; // needed only for correct null analysis
+#endif
             }
+
+            WriteTableCellBefore();
+            Validate(buffer, index, count);
             tw.Write(buffer, index, count);
             WriteTableCellAfter(lastCellInRow);
         }

--- a/Anixe.Ion/SectionHeaderReader.cs
+++ b/Anixe.Ion/SectionHeaderReader.cs
@@ -6,10 +6,11 @@ namespace Anixe.Ion
     {
         public ArraySegment<char> Read(ArraySegment<char> currentLine)
         {
-            var indexOfOpeningCharacter = Array.IndexOf(currentLine.Array, Consts.IonSpecialChars.HeaderOpeningCharacter, currentLine.Offset);
-            var indexOfClosingCharacter = Array.IndexOf(currentLine.Array, Consts.IonSpecialChars.HeaderClosingCharacter, indexOfOpeningCharacter + 1);
+            var array = currentLine.Array!;
+            var indexOfOpeningCharacter = Array.IndexOf(array, Consts.IonSpecialChars.HeaderOpeningCharacter, currentLine.Offset);
+            var indexOfClosingCharacter = Array.IndexOf(array, Consts.IonSpecialChars.HeaderClosingCharacter, indexOfOpeningCharacter + 1);
 
-            return new ArraySegment<char>(currentLine.Array, indexOfOpeningCharacter + 1, indexOfClosingCharacter - indexOfOpeningCharacter - 1);
+            return new ArraySegment<char>(array, indexOfOpeningCharacter + 1, indexOfClosingCharacter - indexOfOpeningCharacter - 1);
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Anixe.Ion CHANGELOG
 
 ## 2.1.2
-- added build for .NET 6
+- added build for .NET 8
 - mark IonReader.CurrentSection as not null if IsSectionHeader was checked before
  
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Anixe.Ion CHANGELOG
 
+## 2.1.2
+- added build for .NET 6
+- mark IonReader.CurrentSection as not null if IsSectionHeader was checked before
+ 
 ## 2.1.1
 - added build for .NET Standard 2.0
 


### PR DESCRIPTION
- added build for .NET 8
- mark IonReader.CurrentSection as not null if IsSectionHeader was checked before
- fix some nullable warnings