### PR TITLE
Change obsolete NUnit.StaticExpect to NExpect

### DIFF
--- a/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
+++ b/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit.StaticExpect" Version="2.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NExpect" Version="2.0.77" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Anixe.Ion.UnitTests/IntegrationTests.cs
+++ b/Anixe.Ion.UnitTests/IntegrationTests.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using NUnit.Framework;
 using System.Collections.Generic;
-using static NUnit.StaticExpect.Expectations;
+using static NExpect.Expectations;
+using NExpect;
 
 namespace Anixe.Ion.UnitTests
 {
@@ -59,149 +60,149 @@ namespace Anixe.Ion.UnitTests
         private void IsSectionHeader_InFirstLine()
         {
             Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[CONTRACT.INFO]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(1));
+            Expect(this.target.CurrentLine).To.Equal("[CONTRACT.INFO]");
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(1);
         }
 
         private void IsProperty_InSecondLine()
         {
             Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("id = \"AAA\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(2));
+            Expect(this.target.CurrentLine).To.Equal("id = \"AAA\"");
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(2);
         }
 
         private void IsProperty_InThirdLine()
         {
             Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("source = \"XXX\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(3));
+            Expect(this.target.CurrentLine).To.Equal("source = \"XXX\"");
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(3);
         }
 
         private void IsEmptyLine_InFourthLine()
         {
             Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(4));
+            Expect(this.target.CurrentLine).To.Equal(string.Empty);
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(4);
         }
 
         private void IsProperty_InFifthLine()
         {
             Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("city = \"YYY\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(5));
+            Expect(this.target.CurrentLine).To.Equal("city = \"YYY\"");
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(5);
         }
 
         private void IsEmptyLine_InSixthLine()
         {
             Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(6));
+            Expect(this.target.CurrentLine).To.Equal(string.Empty);
+            Expect(this.target.CurrentSection).To.Equal("CONTRACT.INFO");
+            Expect(this.target.CurrentLineNumber).To.Equal(6);
         }
 
         private void IsSectionHeader_InSeventhLine()
         {
             Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[DEF.SECTION]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(7));
+            Expect(this.target.CurrentLine).To.Equal("[DEF.SECTION]");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(7);
         }
 
         private void IsTableRow_InEighthLine()
         {
             Expect(this.target.IsTableRow);
             Expect(this.target.IsTableHeaderRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("|  id | 1st_column_description | 2nd_column_description |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(8));
+            Expect(this.target.CurrentLine).To.Equal("|  id | 1st_column_description | 2nd_column_description |");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(8);
         }
 
         private void IsTableHeaderSeparatorRow_InNinethLine()
         {
             Expect(this.target.IsTableHeaderSeparatorRow);
-            Expect(this.target.IsTableHeaderRow, Is.False);
-            Expect(this.target.CurrentLine, Is.EqualTo("|-----|------------------------|------------------------|"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(9));
+            Expect(this.target.IsTableHeaderRow).To.Be.False();
+            Expect(this.target.CurrentLine).To.Equal("|-----|------------------------|------------------------|");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(9);
         }
 
         private void IsTableRow_InTenthLine()
         {
             Expect(this.target.IsTableRow);
             Expect(this.target.IsTableDataRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| 123 | ZZZ                    | VVV                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(10));
+            Expect(this.target.CurrentLine).To.Equal("| 123 | ZZZ                    | VVV                    |");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(10);
         }
 
         private void IsTableRow_InEleventhLine()
         {
             Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| abc | XXX                    | UUU                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(11));
+            Expect(this.target.CurrentLine).To.Equal("| abc | XXX                    | UUU                    |");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(11);
         }
 
         private void IsEmptyLine_InTwelfthLine()
         {
             Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(12));
+            Expect(this.target.CurrentLine).To.Equal(string.Empty);
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(12);
         }
 
         private void IsEmptyLine_InThirteenthLine()
         {
             Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(13));
+            Expect(this.target.CurrentLine).To.Equal(string.Empty);
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(13);
         }
 
         private void IsEmptyLine_InFourteenthLine()
         {
             Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(14));
+            Expect(this.target.CurrentLine).To.Equal(string.Empty);
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION");
+            Expect(this.target.CurrentLineNumber).To.Equal(14);
         }
 
         private void IsTableRow_InEighteenthLine()
         {
             Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| 123 | ZZZ                    | VVV                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(18));
+            Expect(this.target.CurrentLine).To.Equal("| 123 | ZZZ                    | VVV                    |");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION2");
+            Expect(this.target.CurrentLineNumber).To.Equal(18);
         }
 
         private void IsTableHeaderSeparatorRow_InSeventeenthLine()
         {
             Expect(this.target.IsTableHeaderSeparatorRow);
-            Expect(this.target.IsTableHeaderRow, Is.False);
-            Expect(this.target.CurrentLine, Is.EqualTo("|-----|------------------------|------------------------|"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(17));
+            Expect(this.target.IsTableHeaderRow).To.Be.False();
+            Expect(this.target.CurrentLine).To.Equal("|-----|------------------------|------------------------|");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION2");
+            Expect(this.target.CurrentLineNumber).To.Equal(17);
         }
 
         private void IsTableRow_InSixteenthLine()
         {
             Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("|  id | 1st_column_description | 2nd_column_description |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(16));
+            Expect(this.target.CurrentLine).To.Equal("|  id | 1st_column_description | 2nd_column_description |");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION2");
+            Expect(this.target.CurrentLineNumber).To.Equal(16);
         }
 
         private void IsSectionHeader_InFiftheenthLine()
         {
             Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[DEF.SECTION2]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(15));
+            Expect(this.target.CurrentLine).To.Equal("[DEF.SECTION2]");
+            Expect(this.target.CurrentSection).To.Equal("DEF.SECTION2");
+            Expect(this.target.CurrentLineNumber).To.Equal(15);
         }
 
         #endregion

--- a/Anixe.Ion.UnitTests/IonReaderFactoryTests.cs
+++ b/Anixe.Ion.UnitTests/IonReaderFactoryTests.cs
@@ -2,7 +2,8 @@ using System;
 using NUnit.Framework;
 using System.IO;
 using System.Text;
-using static NUnit.StaticExpect.Expectations;
+using static NExpect.Expectations;
+using NExpect;
 
 namespace Anixe.Ion.UnitTests
 {
@@ -24,8 +25,8 @@ namespace Anixe.Ion.UnitTests
         {
             var actual = IonReaderFactory.Create(FileLoader.GetExamplesIonPath());
 
-            Expect(actual, Is.Not.Null);
-            Expect(actual, Is.TypeOf<IonReader>());
+            Expect(actual).Not.To.Be.Null();
+            Expect(actual).To.Be.An.Instance.Of<IonReader>();
         }
 
         [Test]
@@ -33,8 +34,8 @@ namespace Anixe.Ion.UnitTests
         {
             using FileStream fileStream = new FileStream(FileLoader.GetExamplesIonPath(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var ionReader = IonReaderFactory.Create(fileStream);
-            Expect(ionReader, Is.Not.Null);
-            Expect(ionReader, Is.TypeOf<IonReader>());
+            Expect(ionReader).Not.To.Be.Null();
+            Expect(ionReader).To.Be.An.Instance.Of<IonReader>();
         }
 
         [Test]
@@ -44,8 +45,8 @@ namespace Anixe.Ion.UnitTests
 
             using MemoryStream fileStream = new MemoryStream(rawFileContent);
             using var ionReader = IonReaderFactory.Create(fileStream);
-            Expect(ionReader, Is.Not.Null);
-            Expect(ionReader, Is.TypeOf<IonReader>());
+            Expect(ionReader).Not.To.Be.Null();
+            Expect(ionReader).To.Be.An.Instance.Of<IonReader>();
         }
     }
 }


### PR DESCRIPTION
The author of [NUnit.StaticExpect](https://github.com/fluffynuts/NUnit.StaticExpect#deprecated) ecourages to use [NExpect](https://github.com/fluffynuts/NExpect) 