### PR TITLE
Release v3.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,69 @@ dotnet_style_qualification_for_event = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = lf
+
+[*.cs]
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,29 +1,28 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 name: .NET
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
-  build:
+
+  tests:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - uses: actions/checkout@v3
+      
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            9.0.x
+          
+      - name: Install dependencies
+        run: dotnet restore
+        
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/Anixe.Ion.Benchmark/Anixe.Ion.Benchmark.csproj
+++ b/Anixe.Ion.Benchmark/Anixe.Ion.Benchmark.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Anixe.Ion.Benchmark/IonReaderBenchmark.cs
+++ b/Anixe.Ion.Benchmark/IonReaderBenchmark.cs
@@ -1,5 +1,5 @@
-using System;
 using BenchmarkDotNet.Attributes;
+using System;
 
 namespace Anixe.Ion.Benchmark
 {

--- a/Anixe.Ion.Tester/Anixe.Ion.Tester.csproj
+++ b/Anixe.Ion.Tester/Anixe.Ion.Tester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/Anixe.Ion.Tester/Program.cs
+++ b/Anixe.Ion.Tester/Program.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Anixe.Ion.Tester
 {
-    public class MainClass
+    public static class MainClass
     {
         public static void Main(string[] args)
         {
@@ -12,7 +12,7 @@ namespace Anixe.Ion.Tester
             int linesCount = 0;
             double fileSizeInMb = GetFileSizeInMB("example.ion");
 
-            using(IIonReader reader = IonReaderFactory.Create("example.ion"))
+            using (IIonReader reader = IonReaderFactory.Create("example.ion"))
             {
                 stopwatch.Start();
                 linesCount = ReadIonLines(reader);
@@ -34,7 +34,7 @@ namespace Anixe.Ion.Tester
         {
             int result = 0;
 
-            while(reader.Read())
+            while (reader.Read())
             {
                 result++;
             }

--- a/Anixe.Ion.Tester/Properties/AssemblyInfo.cs
+++ b/Anixe.Ion.Tester/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.

--- a/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
+++ b/Anixe.Ion.UnitTests/Anixe.Ion.UnitTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -9,11 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit.StaticExpect" Version="2.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.analyzers" Version="1.22.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Anixe.Ion.UnitTests/CurrentLineVerifierTests.cs
+++ b/Anixe.Ion.UnitTests/CurrentLineVerifierTests.cs
@@ -1,143 +1,158 @@
-using NUnit.Framework;
 using System;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
-    internal class CurrentLineVerifierTests
+    public class CurrentLineVerifierTests
     {
-        private CurrentLineVerifier target = null!;
+        private readonly CurrentLineVerifier target;
 
-        [SetUp]
-        public void Before_Each_Test()
+        public CurrentLineVerifierTests()
         {
             this.target = new CurrentLineVerifier();
         }
 
-        [TestCase("",        ExpectedResult = false)]
-        [TestCase(" ",       ExpectedResult = false)]
-        [TestCase("[NAME]",  ExpectedResult = true)]
-        [TestCase("#[NAME]", ExpectedResult = false)]
-        [TestCase("|date|",  ExpectedResult = false)]
-        [TestCase("|-",      ExpectedResult = false)]
-        [TestCase("|-1",     ExpectedResult = false)]
-        [TestCase("abc",     ExpectedResult = false)]
-        [TestCase(";abc",    ExpectedResult = false)]
-        [TestCase("1abc",    ExpectedResult = false)]
-        public bool IsSectionHeader_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        false)]
+        [InlineData(" ",       false)]
+        [InlineData("[NAME]",  true)]
+        [InlineData("#[NAME]", false)]
+        [InlineData("|date|",  false)]
+        [InlineData("|-",      false)]
+        [InlineData("|-1",     false)]
+        [InlineData("abc",     false)]
+        [InlineData(";abc",    false)]
+        [InlineData("1abc",    false)]
+        public void IsSectionHeader_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsSectionHeader(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsSectionHeader(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        ExpectedResult = false)]
-        [TestCase(" ",       ExpectedResult = false)]
-        [TestCase("[NAME]",  ExpectedResult = false)]
-        [TestCase("#[NAME]", ExpectedResult = false)]
-        [TestCase("|date|",  ExpectedResult = false)]
-        [TestCase("|-",      ExpectedResult = false)]
-        [TestCase("|-1",     ExpectedResult = false)]
-        [TestCase(" abc",     ExpectedResult = true)]
-        [TestCase("abc",     ExpectedResult = true)]
-        [TestCase(";abc",    ExpectedResult = true)]
-        [TestCase("1abc",    ExpectedResult = true)]
-        public bool IsProperty_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        false)]
+        [InlineData(" ",       false)]
+        [InlineData("[NAME]",  false)]
+        [InlineData("#[NAME]", false)]
+        [InlineData("|date|",  false)]
+        [InlineData("|-",      false)]
+        [InlineData("|-1",     false)]
+        [InlineData(" abc",    true)]
+        [InlineData("abc",     true)]
+        [InlineData(";abc",    true)]
+        [InlineData("1abc",    true)]
+        public void IsProperty_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsProperty(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsProperty(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        ExpectedResult = false)]
-        [TestCase(" ",       ExpectedResult = false)]
-        [TestCase("[NAME]",  ExpectedResult = false)]
-        [TestCase("#[NAME]", ExpectedResult = true)]
-        [TestCase("|date|",  ExpectedResult = false)]
-        [TestCase("|-",      ExpectedResult = false)]
-        [TestCase("|-1",     ExpectedResult = false)]
-        [TestCase("abc",     ExpectedResult = false)]
-        [TestCase(";abc",    ExpectedResult = false)]
-        [TestCase("1abc",    ExpectedResult = false)]
-        public bool IsComment_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        false)]
+        [InlineData(" ",       false)]
+        [InlineData("[NAME]",  false)]
+        [InlineData("#[NAME]", true)]
+        [InlineData("|date|",  false)]
+        [InlineData("|-",      false)]
+        [InlineData("|-1",     false)]
+        [InlineData("abc",     false)]
+        [InlineData(";abc",    false)]
+        [InlineData("1abc",    false)]
+        public void IsComment_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsComment(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsComment(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        ExpectedResult = false)]
-        [TestCase(" ",       ExpectedResult = false)]
-        [TestCase("[NAME]",  ExpectedResult = false)]
-        [TestCase("#[NAME]", ExpectedResult = false)]
-        [TestCase("|date|",  ExpectedResult = true)]
-        [TestCase("|-",      ExpectedResult = true)]
-        [TestCase("|-1",     ExpectedResult = true)]
-        [TestCase("abc",     ExpectedResult = false)]
-        [TestCase(";abc",    ExpectedResult = false)]
-        [TestCase("1abc",    ExpectedResult = false)]
-        public bool IsTableRow_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        false)]
+        [InlineData(" ",       false)]
+        [InlineData("[NAME]",  false)]
+        [InlineData("#[NAME]", false)]
+        [InlineData("|date|",  true)]
+        [InlineData("|-",      true)]
+        [InlineData("|-1",     true)]
+        [InlineData("abc",     false)]
+        [InlineData(";abc",    false)]
+        [InlineData("1abc",    false)]
+        public void IsTableRow_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsTableRow(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsTableRow(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        false, ExpectedResult = false)]
-        [TestCase(" ",       false, ExpectedResult = false)]
-        [TestCase("[NAME]",  false, ExpectedResult = false)]
-        [TestCase("#[NAME]", false, ExpectedResult = false)]
-        [TestCase("|date|",  false, ExpectedResult = true)]
-        [TestCase("|-",      false, ExpectedResult = false)]
-        [TestCase("|-1",     false, ExpectedResult = false)]
-        [TestCase("abc",     false, ExpectedResult = false)]
-        [TestCase(";abc",    false, ExpectedResult = false)]
-        [TestCase("1abc",    false, ExpectedResult = false)]
-        [TestCase("| x",     false, ExpectedResult = true)]
-        [TestCase("| x",     true,  ExpectedResult = false)]
-        [TestCase("|-",      true,  ExpectedResult = false)]
-        public bool IsTableHeaderRow_Tests(string currentLine, bool passedHeader)
+        [Theory]
+        [InlineData("",        false, false)]
+        [InlineData(" ",       false, false)]
+        [InlineData("[NAME]",  false, false)]
+        [InlineData("#[NAME]", false, false)]
+        [InlineData("|date|",  false, true)]
+        [InlineData("|-",      false, false)]
+        [InlineData("|-1",     false, false)]
+        [InlineData("abc",     false, false)]
+        [InlineData(";abc",    false, false)]
+        [InlineData("1abc",    false, false)]
+        [InlineData("| x",     false, true)]
+        [InlineData("| x",     true,  false)]
+        [InlineData("|-",      true,  false)]
+        public void IsTableHeaderRow_Tests(string currentLine, bool passedHeader, bool expectedResult)
         {
-            return this.target.IsTableHeaderRow(new ArraySegment<char>(currentLine.ToCharArray()), passedHeader);
+            var result = this.target.IsTableHeaderRow(new ArraySegment<char>(currentLine.ToCharArray()), passedHeader);
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        true,  ExpectedResult = false)]
-        [TestCase(" ",       true,  ExpectedResult = false)]
-        [TestCase("[NAME]",  true,  ExpectedResult = false)]
-        [TestCase("#[NAME]", true,  ExpectedResult = false)]
-        [TestCase("|date|",  true,  ExpectedResult = true)]
-        [TestCase("|-",      true,  ExpectedResult = false)]
-        [TestCase("|-1",     true,  ExpectedResult = false)]
-        [TestCase("abc",     true,  ExpectedResult = false)]
-        [TestCase(";abc",    true,  ExpectedResult = false)]
-        [TestCase("1abc",    true,  ExpectedResult = false)]
-        [TestCase("| x",     false, ExpectedResult = false)]
-        [TestCase("| x",     true,  ExpectedResult = true)]
-        [TestCase("|-",      false, ExpectedResult = false)]
-        public bool IsTableDataRow_Tests(string currentLine, bool passedHeader)
+        [Theory]
+        [InlineData("",        true,  false)]
+        [InlineData(" ",       true,  false)]
+        [InlineData("[NAME]",  true,  false)]
+        [InlineData("#[NAME]", true,  false)]
+        [InlineData("|date|",  true,  true)]
+        [InlineData("|-",      true,  false)]
+        [InlineData("|-1",     true,  false)]
+        [InlineData("abc",     true,  false)]
+        [InlineData(";abc",    true,  false)]
+        [InlineData("1abc",    true,  false)]
+        [InlineData("| x",     false, false)]
+        [InlineData("| x",     true,  true)]
+        [InlineData("|-",      false, false)]
+        public void IsTableDataRow_Tests(string currentLine, bool passedHeader, bool expectedResult)
         {
-            return this.target.IsTableDataRow(new ArraySegment<char>(currentLine.ToCharArray()), passedHeader);
+            var result = this.target.IsTableDataRow(new ArraySegment<char>(currentLine.ToCharArray()), passedHeader);
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        ExpectedResult = false)]
-        [TestCase(" ",       ExpectedResult = false)]
-        [TestCase("[NAME]",  ExpectedResult = false)]
-        [TestCase("#[NAME]", ExpectedResult = false)]
-        [TestCase("|date|",  ExpectedResult = false)]
-        [TestCase("|-",      ExpectedResult = true)]
-        [TestCase("|-1",     ExpectedResult = true)]
-        [TestCase("abc",     ExpectedResult = false)]
-        [TestCase(";abc",    ExpectedResult = false)]
-        [TestCase("1abc",    ExpectedResult = false)]
-        public bool IsTableHeaderSeparatorRow_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        false)]
+        [InlineData(" ",       false)]
+        [InlineData("[NAME]",  false)]
+        [InlineData("#[NAME]", false)]
+        [InlineData("|date|",  false)]
+        [InlineData("|-",      true)]
+        [InlineData("|-1",     true)]
+        [InlineData("abc",     false)]
+        [InlineData(";abc",    false)]
+        [InlineData("1abc",    false)]
+        public void IsTableHeaderSeparatorRow_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsTableHeaderSeparatorRow(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsTableHeaderSeparatorRow(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
 
-        [TestCase("",        ExpectedResult = true)]
-        [TestCase(" ",       ExpectedResult = true)]
-        [TestCase("[NAME]",  ExpectedResult = false)]
-        [TestCase("#[NAME]", ExpectedResult = false)]
-        [TestCase("|date|",  ExpectedResult = false)]
-        [TestCase("|-",      ExpectedResult = false)]
-        [TestCase("|-1",     ExpectedResult = false)]
-        [TestCase("abc",     ExpectedResult = false)]
-        [TestCase(";abc",    ExpectedResult = false)]
-        [TestCase("1abc",    ExpectedResult = false)]
-        public bool IsEmptyLine_Tests(string currentLine)
+        [Theory]
+        [InlineData("",        true)]
+        [InlineData(" ",       true)]
+        [InlineData("[NAME]",  false)]
+        [InlineData("#[NAME]", false)]
+        [InlineData("|date|",  false)]
+        [InlineData("|-",      false)]
+        [InlineData("|-1",     false)]
+        [InlineData("abc",     false)]
+        [InlineData(";abc",    false)]
+        [InlineData("1abc",    false)]
+        public void IsEmptyLine_Tests(string currentLine, bool expectedResult)
         {
-            return this.target.IsEmptyLine(new ArraySegment<char>(currentLine.ToCharArray()));
+            var result = this.target.IsEmptyLine(new ArraySegment<char>(currentLine.ToCharArray()));
+            Assert.Equal(expectedResult, result);
         }
     }
 }

--- a/Anixe.Ion.UnitTests/FileLoader.cs
+++ b/Anixe.Ion.UnitTests/FileLoader.cs
@@ -27,18 +27,14 @@ namespace Anixe.Ion.UnitTests
 
         private static string GetSlnDir()
         {
-#if NET462
-            var currDir = AppDomain.CurrentDomain.BaseDirectory;
-#else
             var currDir = Environment.CurrentDirectory;
-#endif
             if (Directory.EnumerateFiles(currDir, "*.sln").Any())
             {
                 return currDir;
             }
             while (Directory.GetParent(currDir) != null && !Directory.EnumerateFiles(currDir, "*.sln").Any())
             {
-                currDir = Directory.GetParent(currDir).FullName;
+                currDir = Directory.GetParent(currDir)!.FullName;
             }
             return currDir;
         }

--- a/Anixe.Ion.UnitTests/Helpers/BufferWriterTest.cs
+++ b/Anixe.Ion.UnitTests/Helpers/BufferWriterTest.cs
@@ -1,63 +1,64 @@
 ﻿using Anixe.Ion.Helpers;
 using System;
 using System.Buffers;
-using NUnit.Framework;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests.Helpers
 {
     public class BufferWriterTest
     {
-        [Test]
+        [Fact]
         public void BufferWriter_Pool_Handing()
         {
             var pool = new TestPool();
             var writer = new BufferWriter(pool);
-            Assert.AreEqual(0, writer.Count);
+            Assert.Equal(0, writer.Count);
 
             writer.Write(new char[10], 0, 1);
-            Assert.AreEqual(1, writer.Count);
-            Assert.AreEqual(0, pool.currentBufferIndex);
+            Assert.Equal(1, writer.Count);
+            Assert.Equal(0, pool.currentBufferIndex);
 
             writer.Write(new char[10], 0, 2);
-            Assert.AreEqual(3, writer.Count);
-            Assert.AreEqual(1, pool.currentBufferIndex);
+            Assert.Equal(3, writer.Count);
+            Assert.Equal(1, pool.currentBufferIndex);
 
             writer.Dispose();
             //check if all buffers were returned
             Assert.True(Array.TrueForAll(pool.buffers, b => b == null));
         }
 
-        [Test]
+        [Fact]
         public void BufferWriter_Writing_text()
         {
-            var pool = new TestPool();
             var writer = new BufferWriter(ArrayPool<char>.Shared);
             writer.Write("text1".ToCharArray(), 0, "text1".Length);
             writer.Write("something".ToCharArray(), 2, 3);
-            Assert.AreEqual(8, writer.Count);
-            Assert.AreEqual("text1met", new string(writer.WrittenSegment.Array, writer.WrittenSegment.Offset, writer.WrittenSegment.Count));
+            Assert.Equal(8, writer.Count);
+            Assert.NotNull(writer.WrittenSegment.Array);
+            Assert.Equal("text1met", new string(writer.WrittenSegment.Array!, writer.WrittenSegment.Offset, writer.WrittenSegment.Count));
             writer.Dispose();
         }
 
         private class TestPool : ArrayPool<char>
         {
-            public char[]?[] buffers = new char[]?[]
-            {
+            public char[]?[] buffers =
+            [
                 new char[1], new char[3]
-            };
+            ];
             public int currentBufferIndex = -1;
 
             public override char[] Rent(int minimumLength)
             {
                 var buffer = buffers[++currentBufferIndex];
-                Assert.LessOrEqual(buffer.Length, minimumLength);
+                Assert.NotNull(buffer);
+                Assert.True(buffer!.Length <= minimumLength);
                 return buffer;
             }
 
             public override void Return(char[] array, bool clearArray = false)
             {
                 var idx = Array.IndexOf(this.buffers, array);
-                Assert.IsNotNull(this.buffers[idx]);
+                Assert.NotNull(this.buffers[idx]);
                 this.buffers[idx] = null;
                 Assert.False(clearArray);
             }

--- a/Anixe.Ion.UnitTests/IntegrationTests.cs
+++ b/Anixe.Ion.UnitTests/IntegrationTests.cs
@@ -1,22 +1,27 @@
 ﻿using System;
-using NUnit.Framework;
 using System.Collections.Generic;
-using static NUnit.StaticExpect.Expectations;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
-    [TestFixture]
-    public class IntegrationTests
+    public sealed class IntegrationTests : IDisposable
     {
-        private IIonReader target = null!;
-        private List<Action> assertions = null!;
+        private readonly IIonReader target;
 
-        [OneTimeSetUp]
-        public void Before_All_Test()
+        public IntegrationTests()
         {
             this.target = IonReaderFactory.Create(FileLoader.GetExamplesIonPath());
+        }
 
-            this.assertions = new List<Action>
+        public void Dispose()
+        {
+            this.target.Dispose();
+        }
+
+        [Fact]
+        public void Verifies_Each_Ion_File_Line()
+        {
+            var assertions = new List<Action>
             {
                 IsSectionHeader_InFirstLine,
                 IsProperty_InSecondLine,
@@ -37,174 +42,159 @@ namespace Anixe.Ion.UnitTests
                 IsTableHeaderSeparatorRow_InSeventeenthLine,
                 IsTableRow_InEighteenthLine,
             };
-        }
 
-        [OneTimeTearDown]
-        public void After_All_Test()
-        {
-            this.target.Dispose();
-        }
-
-        [Test]
-        public void Verifies_Each_Ion_File_Line()
-        {
-            while(target.Read())
+            while (target.Read())
             {
-                this.assertions[this.target.CurrentLineNumber - 1].Invoke();
+                assertions[this.target.CurrentLineNumber - 1].Invoke();
             }
         }
 
-        #region Assertions
-
         private void IsSectionHeader_InFirstLine()
         {
-            Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[CONTRACT.INFO]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(1));
+            Assert.True(this.target.IsSectionHeader);
+            Assert.Equal("[CONTRACT.INFO]", this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(1, this.target.CurrentLineNumber);
         }
 
         private void IsProperty_InSecondLine()
         {
-            Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("id = \"AAA\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(2));
+            Assert.True(this.target.IsProperty);
+            Assert.Equal("id = \"AAA\"", this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(2, this.target.CurrentLineNumber);
         }
 
         private void IsProperty_InThirdLine()
         {
-            Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("source = \"XXX\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(3));
+            Assert.True(this.target.IsProperty);
+            Assert.Equal("source = \"XXX\"", this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(3, this.target.CurrentLineNumber);
         }
 
         private void IsEmptyLine_InFourthLine()
         {
-            Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(4));
+            Assert.True(this.target.IsEmptyLine);
+            Assert.Equal(string.Empty, this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(4, this.target.CurrentLineNumber);
         }
 
         private void IsProperty_InFifthLine()
         {
-            Expect(this.target.IsProperty);
-            Expect(this.target.CurrentLine, Is.EqualTo("city = \"YYY\""));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(5));
+            Assert.True(this.target.IsProperty);
+            Assert.Equal("city = \"YYY\"", this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(5, this.target.CurrentLineNumber);
         }
 
         private void IsEmptyLine_InSixthLine()
         {
-            Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("CONTRACT.INFO"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(6));
+            Assert.True(this.target.IsEmptyLine);
+            Assert.Equal(string.Empty, this.target.CurrentLine);
+            Assert.Equal("CONTRACT.INFO", this.target.CurrentSection);
+            Assert.Equal(6, this.target.CurrentLineNumber);
         }
 
         private void IsSectionHeader_InSeventhLine()
         {
-            Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[DEF.SECTION]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(7));
+            Assert.True(this.target.IsSectionHeader);
+            Assert.Equal("[DEF.SECTION]", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(7, this.target.CurrentLineNumber);
         }
 
         private void IsTableRow_InEighthLine()
         {
-            Expect(this.target.IsTableRow);
-            Expect(this.target.IsTableHeaderRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("|  id | 1st_column_description | 2nd_column_description |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(8));
+            Assert.True(this.target.IsTableRow);
+            Assert.True(this.target.IsTableHeaderRow);
+            Assert.Equal("|  id | 1st_column_description | 2nd_column_description |", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(8, this.target.CurrentLineNumber);
         }
 
         private void IsTableHeaderSeparatorRow_InNinethLine()
         {
-            Expect(this.target.IsTableHeaderSeparatorRow);
-            Expect(this.target.IsTableHeaderRow, Is.False);
-            Expect(this.target.CurrentLine, Is.EqualTo("|-----|------------------------|------------------------|"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(9));
+            Assert.True(this.target.IsTableHeaderSeparatorRow);
+            Assert.False(this.target.IsTableHeaderRow);
+            Assert.Equal("|-----|------------------------|------------------------|", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(9, this.target.CurrentLineNumber);
         }
 
         private void IsTableRow_InTenthLine()
         {
-            Expect(this.target.IsTableRow);
-            Expect(this.target.IsTableDataRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| 123 | ZZZ                    | VVV                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(10));
+            Assert.True(this.target.IsTableRow);
+            Assert.True(this.target.IsTableDataRow);
+            Assert.Equal("| 123 | ZZZ                    | VVV                    |", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(10, this.target.CurrentLineNumber);
         }
 
         private void IsTableRow_InEleventhLine()
         {
-            Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| abc | XXX                    | UUU                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(11));
+            Assert.True(this.target.IsTableRow);
+            Assert.Equal("| abc | XXX                    | UUU                    |", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(11, this.target.CurrentLineNumber);
         }
 
         private void IsEmptyLine_InTwelfthLine()
         {
-            Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(12));
+            Assert.True(this.target.IsEmptyLine);
+            Assert.Equal(string.Empty, this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(12, this.target.CurrentLineNumber);
         }
 
         private void IsEmptyLine_InThirteenthLine()
         {
-            Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(13));
+            Assert.True(this.target.IsEmptyLine);
+            Assert.Equal(string.Empty, this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(13, this.target.CurrentLineNumber);
         }
 
         private void IsEmptyLine_InFourteenthLine()
         {
-            Expect(this.target.IsEmptyLine);
-            Expect(this.target.CurrentLine, Is.EqualTo(string.Empty));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(14));
+            Assert.True(this.target.IsEmptyLine);
+            Assert.Equal(string.Empty, this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION", this.target.CurrentSection);
+            Assert.Equal(14, this.target.CurrentLineNumber);
         }
 
         private void IsTableRow_InEighteenthLine()
         {
-            Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("| 123 | ZZZ                    | VVV                    |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(18));
+            Assert.True(this.target.IsTableRow);
+            Assert.Equal("| 123 | ZZZ                    | VVV                    |", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION2", this.target.CurrentSection);
+            Assert.Equal(18, this.target.CurrentLineNumber);
         }
 
         private void IsTableHeaderSeparatorRow_InSeventeenthLine()
         {
-            Expect(this.target.IsTableHeaderSeparatorRow);
-            Expect(this.target.IsTableHeaderRow, Is.False);
-            Expect(this.target.CurrentLine, Is.EqualTo("|-----|------------------------|------------------------|"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(17));
+            Assert.True(this.target.IsTableHeaderSeparatorRow);
+            Assert.False(this.target.IsTableHeaderRow);
+            Assert.Equal("|-----|------------------------|------------------------|", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION2", this.target.CurrentSection);
+            Assert.Equal(17, this.target.CurrentLineNumber);
         }
 
         private void IsTableRow_InSixteenthLine()
         {
-            Expect(this.target.IsTableRow);
-            Expect(this.target.CurrentLine, Is.EqualTo("|  id | 1st_column_description | 2nd_column_description |"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(16));
+            Assert.True(this.target.IsTableRow);
+            Assert.Equal("|  id | 1st_column_description | 2nd_column_description |", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION2", this.target.CurrentSection);
+            Assert.Equal(16, this.target.CurrentLineNumber);
         }
 
         private void IsSectionHeader_InFiftheenthLine()
         {
-            Expect(this.target.IsSectionHeader);
-            Expect(this.target.CurrentLine, Is.EqualTo("[DEF.SECTION2]"));
-            Expect(this.target.CurrentSection, Is.EqualTo("DEF.SECTION2"));
-            Expect(this.target.CurrentLineNumber, Is.EqualTo(15));
+            Assert.True(this.target.IsSectionHeader);
+            Assert.Equal("[DEF.SECTION2]", this.target.CurrentLine);
+            Assert.Equal("DEF.SECTION2", this.target.CurrentSection);
+            Assert.Equal(15, this.target.CurrentLineNumber);
         }
-
-        #endregion
     }
 }
-

--- a/Anixe.Ion.UnitTests/IonExtensionsTest.cs
+++ b/Anixe.Ion.UnitTests/IonExtensionsTest.cs
@@ -1,13 +1,13 @@
-﻿using NUnit.Framework;
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
   public class IonExtensionsTest
   {
-    [Test]
+    [Fact]
     public void ReadProperty_Test()
     {
       var reader = CreateReaderForInput("\"some_key\" = \"some_value\"");
@@ -16,28 +16,27 @@ namespace Anixe.Ion.UnitTests
       ReadOnlySpan<char> key = ionProperty.Key;
       ReadOnlySpan<char> value = ionProperty.Value;
 
-      Assert.AreEqual("some_key", key.ToString());
-      Assert.AreEqual("some_value", value.ToString());
+      Assert.Equal("some_key", key.ToString());
+      Assert.Equal("some_value", value.ToString());
 
       // getting more than one time
-      Assert.AreEqual("some_key", ionProperty.Key.ToString());
+      Assert.Equal("some_key", ionProperty.Key.ToString());
 
       // reading property one more time
       var newIonProperty = reader.ReadProperty();
-      Assert.AreEqual("some_key", newIonProperty.Key.ToString());
+      Assert.Equal("some_key", newIonProperty.Key.ToString());
     }
 
-    [Test]
-    public void ReadProperty_Empty_Property_Test()
+    [Theory]
+    [InlineData(" = ")]
+    [InlineData("\"\" = \"\"")]
+    public void ReadProperty_Empty_Property_Test(string input)
     {
-      var reader = CreateReaderForInput("\"\" = \"\"");
+      var reader = CreateReaderForInput(input);
       var ionProperty = reader.ReadProperty();
-      Assert.AreEqual("", ionProperty.Key.ToString());
-      Assert.AreEqual("", ionProperty.Value.ToString());
 
-      var secondReader = CreateReaderForInput(" = ");
-      Assert.AreEqual("", ionProperty.Key.ToString());
-      Assert.AreEqual("", ionProperty.Value.ToString());
+      Assert.Equal(string.Empty, ionProperty.Key.ToString());
+      Assert.Equal(string.Empty, ionProperty.Value.ToString());
     }
 
     private static IIonReader CreateReaderForInput(string input)

--- a/Anixe.Ion.UnitTests/IonPropertyTest.cs
+++ b/Anixe.Ion.UnitTests/IonPropertyTest.cs
@@ -1,23 +1,24 @@
-﻿using NUnit.Framework;
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
   public class IonPropertyTest
   {
-    [TestCase("some_key = some_value", "some_key", "some_value")]
-    [TestCase("\"some_key\" = \"some_value\"", "some_key", "some_value")]
-    [TestCase("\"some_key\" = 1", "some_key", "1")]
-    [TestCase(" \"some_key\" = \"some_value\" ", "some_key", "some_value")]
-    [TestCase("\"some_key\": \"some_value\"", "", "\"some_key\": \"some_value\"")]
-    [TestCase("\"\" = \"\"", "", "")]
-    [TestCase(" = ", "", "")]
-    [TestCase("some key = some value", "some key", "some value")]
-    [TestCase("key=some=value", "key", "some=value")]
-    [TestCase("some_setting = \"true\"", "some_setting", "true")]
-    [TestCase("some_setting =", "some_setting", "")]
+    [Theory]
+    [InlineData("some_key = some_value", "some_key", "some_value")]
+    [InlineData("\"some_key\" = \"some_value\"", "some_key", "some_value")]
+    [InlineData("\"some_key\" = 1", "some_key", "1")]
+    [InlineData(" \"some_key\" = \"some_value\" ", "some_key", "some_value")]
+    [InlineData("\"some_key\": \"some_value\"", "", "\"some_key\": \"some_value\"")]
+    [InlineData("\"\" = \"\"", "", "")]
+    [InlineData(" = ", "", "")]
+    [InlineData("some key = some value", "some key", "some value")]
+    [InlineData("key=some=value", "key", "some=value")]
+    [InlineData("some_setting = \"true\"", "some_setting", "true")]
+    [InlineData("some_setting =", "some_setting", "")]
     public void IonProperty_Test(string input, string key, string value)
     {
       using var reader = IonReaderFactory.Create(new MemoryStream(Encoding.UTF8.GetBytes(input)));
@@ -25,13 +26,14 @@ namespace Anixe.Ion.UnitTests
       Assert.True(reader.IsProperty);
 
       var property = new IonProperty(reader);
-      Assert.AreEqual(key, property.Key.ToString());
-      Assert.AreEqual(value, property.Value.ToString());
+      Assert.Equal(key, property.Key.ToString());
+      Assert.Equal(value, property.Value.ToString());
     }
 
-    [TestCase("")]
-    [TestCase("[AAA]")]
-    [TestCase("|--|--|")]
+    [Theory]
+    [InlineData("")]
+    [InlineData("[AAA]")]
+    [InlineData("|--|--|")]
     public void IonProperty_Throws_InvalidOperationException(string input)
     {
       using var reader = IonReaderFactory.Create(new MemoryStream(Encoding.UTF8.GetBytes(input)));

--- a/Anixe.Ion.UnitTests/IonReaderFactoryTests.cs
+++ b/Anixe.Ion.UnitTests/IonReaderFactoryTests.cs
@@ -1,51 +1,54 @@
 using System;
-using NUnit.Framework;
 using System.IO;
 using System.Text;
-using static NUnit.StaticExpect.Expectations;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
-    internal class IonReaderFactoryTests
+    public class IonReaderFactoryTests
     {
-        [TestCase(null,                             "File path must be defined!",                                TestName = "Throws exception when file path is null")]
-        [TestCase("",                               "File path must be defined!",                                TestName = "Throws exception when file path is empty text")]
-        [TestCase(" ",                              "File path must be defined!",                                TestName = "Throws exception when file path is whitespace")]
-        [TestCase("Examples/not_existing_file.ion", "File '\"Examples/not_existing_file.ion\"' does not exist!", TestName = "Throws exception when file does not exist")]
-        public void Throws_Exception_When_FilePath_Does_Not_Exists(string filePath, string expectedExceptionMessage)
+        [Theory]
+        [InlineData(null,                             "File path must be defined!")] // Throws exception when file path is null
+        [InlineData("",                               "File path must be defined!")] // Throws exception when file path is empty text
+        [InlineData(" ",                              "File path must be defined!")] // Throws exception when file path is whitespace
+        [InlineData("Examples/not_existing_file.ion", "File 'Examples/not_existing_file.ion' does not exist!")] // Throws exception when file does not exist
+        public void Throws_Exception_When_FilePath_Does_Not_Exists(string? filePath, string expectedExceptionMessage)
         {
+#pragma warning disable CS8604 // Possible null reference argument. - intended!
             void subject() => IonReaderFactory.Create(filePath);
+#pragma warning restore CS8604
 
-            Assert.Throws<ArgumentException>(subject, expectedExceptionMessage);
+            var ex = Assert.Throws<ArgumentException>(subject);
+            Assert.Equal(expectedExceptionMessage, ex.Message);
         }
 
-        [Test]
+        [Fact]
         public void Creates_IonReader_For_Existing_File_Path()
         {
             var actual = IonReaderFactory.Create(FileLoader.GetExamplesIonPath());
 
-            Expect(actual, Is.Not.Null);
-            Expect(actual, Is.TypeOf<IonReader>());
+            Assert.NotNull(actual);
+            Assert.IsType<IonReader>(actual);
         }
 
-        [Test]
+        [Fact]
         public void Creates_IonReader_For_FileStream()
         {
             using FileStream fileStream = new FileStream(FileLoader.GetExamplesIonPath(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var ionReader = IonReaderFactory.Create(fileStream);
-            Expect(ionReader, Is.Not.Null);
-            Expect(ionReader, Is.TypeOf<IonReader>());
+            Assert.NotNull(ionReader);
+            Assert.IsType<IonReader>(ionReader);
         }
 
-        [Test]
+        [Fact]
         public void Creates_IonReader_For_MemoryStream()
         {
             var rawFileContent = Encoding.UTF8.GetBytes(File.ReadAllText(FileLoader.GetExamplesIonPath()));
 
             using MemoryStream fileStream = new MemoryStream(rawFileContent);
             using var ionReader = IonReaderFactory.Create(fileStream);
-            Expect(ionReader, Is.Not.Null);
-            Expect(ionReader, Is.TypeOf<IonReader>());
+            Assert.NotNull(ionReader);
+            Assert.IsType<IonReader>(ionReader);
         }
     }
 }

--- a/Anixe.Ion.UnitTests/IonWriterTests.cs
+++ b/Anixe.Ion.UnitTests/IonWriterTests.cs
@@ -1,145 +1,145 @@
-﻿using System;
+﻿using Anixe.Ion.Exceptions;
+using System;
 using System.IO;
 using System.Text;
-using Anixe.Ion.Exceptions;
-using NUnit.Framework;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
-    internal class IonWriterTests
+    public class IonWriterTests
     {
-        [Test]
+        [Fact]
         public void Should_Write_Section()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_String_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", "value");
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=\"value\"{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=\"value\"{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Escaped_String_Property()
         {
             var sb = new StringBuilder();
-            using (var subject = new IonWriter(new StringWriter(sb), new WriterOptions{ EscapeQuotes = true}))
+            using (var subject = new IonWriter(new StringWriter(sb), new WriterOptions { EscapeQuotes = true }))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", "value");
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=\\\"value\\\"{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=\\\"value\\\"{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Escaped_Newlines_String_Property()
         {
             var sb = new StringBuilder();
-            using (var subject = new IonWriter(new StringWriter(sb), new WriterOptions{ EscapeQuotes = true, EscapeNewLineChars = true}))
+            using (var subject = new IonWriter(new StringWriter(sb), new WriterOptions { EscapeQuotes = true, EscapeNewLineChars = true }))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", "value");
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=\\\"value\\\"{0}", Consts.IonSpecialChars.NewLineEscaped), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=\\\"value\\\"{0}", Consts.IonSpecialChars.NewLineEscaped), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Char_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 'x');
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=\"x\"{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=\"x\"{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Integer_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 1000);
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=1000{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=1000{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Double_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 25.22d);
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=25.22{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=25.22{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Decimal_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 25.22m);
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=25.22{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=25.22{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Float_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 24.3f);
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=24.3{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=24.3{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Custom_Property()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", (tw) =>
                 {
                     tw.Write('[');
@@ -152,28 +152,28 @@ namespace Anixe.Ion.UnitTests
                     tw.Write(23);
                     tw.Write(']');
                 });
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=[23,23,23,23]{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=[23,23,23,23]{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Multiple_Properties()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", 24.3f);
                 subject.WriteProperty("test1", "test1val");
                 subject.WriteProperty("test2", true);
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
             }
-            Assert.AreEqual(string.Format("[META]{0}test=24.3{0}test1=\"test1val\"{0}test2=true{0}", Environment.NewLine), sb.ToString());
+            Assert.Equal(string.Format("[META]{0}test=24.3{0}test1=\"test1val\"{0}test2=true{0}", Environment.NewLine), sb.ToString());
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Table_Header()
         {
             var header = new string[] { "key", "val" };
@@ -188,14 +188,14 @@ namespace Anixe.Ion.UnitTests
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("DATA");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteTableHeader(header);
-                Assert.AreEqual(WriterState.Section | WriterState.TableHeader, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableHeader, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Table_Rows()
         {
             var row = new string[] { "unit_type", "miles" };
@@ -210,40 +210,49 @@ namespace Anixe.Ion.UnitTests
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("DATA");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteTableRow(row);
                 subject.WriteTableRow(row);
-                Assert.AreEqual(WriterState.Section | WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
-        public void IIonWriter_WriteTableCell_Throws_InvalidTableCellDataException()
+        [Fact]
+        public void IIonWriter_WriteTableCell_Escapes()
+        {
+            Assert.Equal("""| \n |""", WriteTableCell(tw => tw.WriteTableCell("\n")));
+            Assert.Equal("""| \| |""", WriteTableCell(tw => tw.WriteTableCell("|")));
+            Assert.Equal("""| \n |""", WriteTableCell(tw => tw.WriteTableCell('\n')));
+            Assert.Equal("""| \| |""", WriteTableCell(tw => tw.WriteTableCell('|')));
+            Assert.Equal("""| \n |""", WriteTableCell(tw => tw.WriteTableCell("\n".ToCharArray(), 0, 1)));
+            Assert.Equal("""| \| |""", WriteTableCell(tw => tw.WriteTableCell("|".ToCharArray(), 0, 1)));
+            Assert.Equal("""| \n |""", WriteTableCell(tw => tw.WriteTableCell("\n".AsSpan())));
+            Assert.Equal("""| \| |""", WriteTableCell(tw => tw.WriteTableCell("|".AsSpan())));
+
+            static string WriteTableCell(Action<IIonWriter> action)
+            {
+                var sb = new StringBuilder();
+                using (var subject = new IonWriter(new StringWriter(sb)))
+                {
+                    action(subject);
+                }
+                return sb.ToString();
+            }
+        }
+
+        [Fact]
+        public void IIonWriter_WriteTableRow_Escapes()
         {
             var sb = new StringBuilder();
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableCell("\n"));
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableCell("|"));
-
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableCell("\n".ToCharArray(), 0, 1));
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableCell("|".ToCharArray(), 0, 1));
+                subject.WriteTableRow("\n", "|", "other");
             }
+            Assert.Equal("""| \n | \| | other |""", sb.ToString().TrimEnd());
         }
 
-        [Test]
-        public void IIonWriter_WriteTableRow_Throws_InvalidTableCellDataException()
-        {
-            var sb = new StringBuilder();
-            using (var subject = new IonWriter(new StringWriter(sb)))
-            {
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableRow(new[] { "\n" }));
-                Assert.Throws<InvalidTableCellDataException>(() => subject.WriteTableRow(new[] { "|" }));
-            }
-        }
-
-        [Test]
+        [Fact]
         public void Should_Write_Table_Outside_Section()
         {
             var row = new string[] { "unit_type", "miles" };
@@ -258,12 +267,12 @@ namespace Anixe.Ion.UnitTests
             {
                 subject.WriteTableRow(row);
                 subject.WriteTableRow(row);
-                Assert.AreEqual(WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Table_Cell_With_Custom_Value()
         {
             var expected = new string[]
@@ -281,16 +290,16 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteTableCell((tw) => tw.Write("miles"), true);
                 subject.WriteTableCell("unit_type");
                 subject.WriteTableCell("miles", true);
-                Assert.AreEqual(WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.TableRow, subject.State);
                 subject.WriteEmptyLine();
-                Assert.AreEqual(WriterState.None, subject.State);
+                Assert.Equal(WriterState.None, subject.State);
                 subject.WriteTableCell((tw) => tw.Write("my custom table"), true);
-                Assert.AreEqual(WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Tables()
         {
             var row = new string[] { "unit_type", "miles" };
@@ -309,20 +318,20 @@ namespace Anixe.Ion.UnitTests
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("DATA");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteTableRow(row);
                 subject.WriteTableRow(row);
-                Assert.AreEqual(WriterState.Section | WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableRow, subject.State);
                 subject.WriteEmptyLine();
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteTableRow(row2);
                 subject.WriteTableRow(row2);
-                Assert.AreEqual(WriterState.Section | WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Whole_Table()
         {
             var header = new string[] { "key", "val" };
@@ -340,16 +349,16 @@ namespace Anixe.Ion.UnitTests
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("DATA");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteTableHeader(header);
                 subject.WriteTableRow(row);
                 subject.WriteTableRow(row);
-                Assert.AreEqual(WriterState.Section | WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Write_Multiple_Sections()
         {
             var header = new string[] { "key", "val" };
@@ -372,22 +381,22 @@ namespace Anixe.Ion.UnitTests
             using (var subject = new IonWriter(new StringWriter(sb)))
             {
                 subject.WriteSection("META");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("test", "value");
-                Assert.AreEqual(WriterState.Section | WriterState.Property, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.Property, subject.State);
                 subject.WriteSection("DATA");
-                Assert.AreEqual(WriterState.Section, subject.State);
+                Assert.Equal(WriterState.Section, subject.State);
                 subject.WriteProperty("table_name", "test");
                 subject.WriteEmptyLine();
                 subject.WriteTableHeader(header);
                 subject.WriteTableRow(row);
                 subject.WriteTableRow(row);
-                Assert.AreEqual(WriterState.Section | WriterState.TableRow, subject.State);
+                Assert.Equal(WriterState.Section | WriterState.TableRow, subject.State);
             }
-            CollectionAssert.AreEquivalent(expected, sb.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+            Assert.Equivalent(expected, sb.ToString().Split(Environment.NewLine, StringSplitOptions.None));
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Section()
         {
             static void action()
@@ -397,23 +406,24 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteSection(null!);
             }
 
-            Assert.Throws<ArgumentNullException>(action, "Section name must be provided");
+            Assert.Throws<ArgumentNullException>("name", action);
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Table()
         {
             static void action()
             {
                 var sb = new StringBuilder();
                 using var subject = new IonWriter(new StringWriter(sb));
-                subject.WriteTableHeader(null!);
+                subject.WriteTableHeader([]);
             }
 
-            Assert.Throws<InvalidOperationException>(action, "Only section can be at the top of document");
+            var ex = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal("Only section can be at the top of document", ex.Message);
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Table_Columns()
         {
             static void action()
@@ -424,10 +434,10 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteTableHeader(null!);
             }
 
-            Assert.Throws<ArgumentNullException>(action, "Cannot create empty table header");
+            var ex = Assert.Throws<ArgumentNullException>("columns", action);
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Table_Headers()
         {
             static void action()
@@ -441,10 +451,11 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteTableHeader(header);
             }
 
-            Assert.Throws<InvalidOperationException>(action, "Table can have ony one header");
+            var ex = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal("Table can have only one header", ex.Message);
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Table_Row()
         {
             static void action()
@@ -459,10 +470,11 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteTableRow(row);
             }
 
-            Assert.Throws<ArgumentException>(action, "Must provide the same number of columns within the same table");
+            var ex = Assert.Throws<ArgumentException>(action);
+            Assert.Equal("Must provide the same number of columns within the same table (Parameter 'columns')", ex.Message);
         }
 
-        [Test]
+        [Fact]
         public void Should_Validate_Table_Rows()
         {
             static void action()
@@ -477,7 +489,8 @@ namespace Anixe.Ion.UnitTests
                 subject.WriteTableRow(row2);
             }
 
-            Assert.Throws<ArgumentException>(action, "Must provide the same number of columns within the same table");
+            var ex = Assert.Throws<ArgumentException>(action);
+            Assert.Equal("Must provide the same number of columns within the same table (Parameter 'columns')", ex.Message);
         }
     }
 }

--- a/Anixe.Ion.UnitTests/SectionHeaderReaderTests.cs
+++ b/Anixe.Ion.UnitTests/SectionHeaderReaderTests.cs
@@ -1,25 +1,26 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
-    internal class SectionHeaderReaderTests
+    public class SectionHeaderReaderTests
     {
-        private SectionHeaderReader target = null!;
+        private readonly SectionHeaderReader target;
 
-        [SetUp]
-        public void Before_Each_Test()
+        public SectionHeaderReaderTests()
         {
             this.target = new SectionHeaderReader();
         }
 
-        [TestCase("[ABC]",       ExpectedResult = "ABC")]
-        [TestCase("[ABC]xyz",    ExpectedResult = "ABC")]
-        [TestCase("[ABC][1]xyz", ExpectedResult = "ABC")]
-        [TestCase("[ABC] ",      ExpectedResult = "ABC")]
-        public string Read_Tests(string currentLine)
+        [Theory]
+        [InlineData("[ABC]",       "ABC")]
+        [InlineData("[ABC]xyz",    "ABC")]
+        [InlineData("[ABC][1]xyz", "ABC")]
+        [InlineData("[ABC] ",      "ABC")]
+        public void Read_Tests(string currentLine, string expected)
         {
             var actual = this.target.Read(new System.ArraySegment<char>(currentLine.ToCharArray()));
-            return new string(actual.Array!, actual.Offset, actual.Count);
+            var result = new string(actual.Array!, actual.Offset, actual.Count);
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/Anixe.Ion.UnitTests/SectionReaderTest.cs
+++ b/Anixe.Ion.UnitTests/SectionReaderTest.cs
@@ -1,11 +1,11 @@
 using System.IO;
-using NUnit.Framework;
+using Xunit;
 
 namespace Anixe.Ion.UnitTests
 {
   public class SectionReaderTest
   {
-    [Test]
+    [Fact]
     public void Should_Read_Multiple_Sections()
     {
       var counter = 0;
@@ -15,12 +15,12 @@ namespace Anixe.Ion.UnitTests
         var sectionReader = new GenericSectionReader(reader);
         sectionReader.OnReadSection += (sender, args) =>
         {
-          Assert.That(args.SectionName, Is.AnyOf("META", "INSURANCE"));
+          Assert.Contains(args.SectionName, new[] { "META", "INSURANCE" });
           counter++;
         };
         sectionReader.Read();
       }
-      Assert.AreEqual(2, counter);
+      Assert.Equal(2, counter);
     }
   }
 }

--- a/Anixe.Ion.UnitTests/TableRowReaderTests.cs
+++ b/Anixe.Ion.UnitTests/TableRowReaderTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Xunit;
+
+namespace Anixe.Ion.UnitTests;
+
+public class TableRowReaderTests
+{
+    public static TheoryData<string, string[]> GetTableRowReaderData() => new()
+    {
+        { "| Berlin Mitte Kronenstraße |", ["Berlin Mitte Kronenstraße"] },
+        { "|DANS PARKING AUTOCIT®Õ NIVEAU -2 |", ["DANS PARKING AUTOCIT®Õ NIVEAU -2"] },
+        { "|Column1|Column2|Column3|", ["Column1", "Column2", "Column3"] },
+        { "|Value1\\|Escaped|Value2\\nNewLine|", ["Value1|Escaped", "Value2\nNewLine"] },
+        { "|SingleValue|", ["SingleValue"] },
+        { "|ValueWith\\|Multiple\\|Escapes|", ["ValueWith|Multiple|Escapes"] },
+        { "|ValueWith\\nNewLine|", ["ValueWith\nNewLine"] },
+        { "||", [""] },
+        { "| |", [""] },
+        { "|a|", ["a"] },
+        { "|a|\n", ["a"] },
+        { "| a |", ["a"] },
+        { "| \\\\ |", ["\\\\"] },
+        { "| \\|\\ | |", ["|\\", ""] },
+        { "| \\|\\ ||", ["|\\", ""] },
+        { "| \\n |", ["\n"] },
+        { "| \\\\n |", ["\\\n"] },
+    };
+
+    [Theory]
+    [MemberData(nameof(GetTableRowReaderData))]
+    public void ReadNext_ShouldReturnExpectedValues(string input, string[] expectedValues)
+    {
+        var reader = new TableRowReader(input.AsSpan());
+        foreach (var expectedValue in expectedValues)
+        {
+            var actualValue = reader.ReadNext();
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        try
+        {
+            reader.ReadNext();
+            Assert.Fail("Expected InvalidOperationException was not thrown.");
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected exception, do nothing
+        }
+    }
+
+    [Theory]
+    [InlineData("#|x|")]
+    [InlineData("|x")]
+    [InlineData("x|")]
+    [InlineData("")]
+    [InlineData("[XXX]")]
+    public void ReadNext_ShouldThrow_WhenRowHasIncorrectFormat(string rowLine)
+    {
+        try
+        {
+            new TableRowReader(rowLine);
+            Assert.Fail("Expected FormatException was not thrown.");
+        }
+        catch (FormatException)
+        {
+            // Expected exception, do nothing
+        }
+    }
+}

--- a/Anixe.Ion.sln
+++ b/Anixe.Ion.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31129.286
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Anixe.Ion", "Anixe.Ion\Anixe.Ion.csproj", "{679149D4-BF21-46BE-96DE-A162DA69AE02}"
 EndProject
@@ -13,8 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Anixe.Ion.Benchmark", "Anix
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{420DF218-D3B0-4079-8D1B-8A3337F98D15}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		CHANGELOG.md = CHANGELOG.md
 		README.md = README.md
+		.github\workflows\tests.yml = .github\workflows\tests.yml
 	EndProjectSection
 EndProject
 Global

--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -1,15 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>2.1.1</Version>
+    <Version>3.0.0</Version>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RepositoryUrl>https://github.com/anixe/ion_cs</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageProjectUrl>https://www.nuget.org/packages/Anixe.Ion/</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/anixe/ion_cs/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSource>true</IncludeSource>
+    <IncludeSymbols>true</IncludeSymbols>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+    <Company>ANIXE Polska Sp. z o.o.</Company>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+  <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Anixe.Ion/Consts.cs
+++ b/Anixe.Ion/Consts.cs
@@ -4,29 +4,18 @@ namespace Anixe.Ion
 {
     internal static class Consts
     {
-        public const string False = "false";
-        public const string True = "true";
-        public static readonly char[] ProhibitedTableCellCharacters = new[] { '\n', '|' };
-
-        public static class ErrorMessages
-        {
-            public const string UndefinedFilePath = "File path must be defined!";
-            public const string FileDoesNotExist  = "File '{0}' does not exist!";
-        }
-
         public static class IonSpecialChars
         {
             public readonly static string NewLineEscaped = Environment.NewLine.Length == 1 ? "\\n" : "\\r\\n";
-            public const char EscapeCharacter               = '\\';
-            public const char HeaderOpeningCharacter        = '[';
-            public const char HeaderClosingCharacter        = ']';
-            public const char CommentCharacter              = '#';
-            public const char TableOpeningCharacter         = '|';
-            public const char TableHeaderSeparatorCharacter = '-';
-            public const char WriteSpaceCharacter = ' ';
-            public const char QuotationCharacter = '"';
-            public const char EqualsCharacter = '=';
+            public const char EscapeCharacter      = '\\';
+            public const char SectionHeaderOpening = '[';
+            public const char SectionHeaderClosing = ']';
+            public const char BeginCommentLine     = '#';
+            public const char TableColumnSeparator = '|';
+            public const char TableHeaderSeparator = '-';
+            public const char TableCellPadding     = ' ';
+            public const char PropertyQuotation    = '"';
+            public const char PropertyAssignment   = '=';
         }
     }
 }
-

--- a/Anixe.Ion/CurrentLineVerifier.cs
+++ b/Anixe.Ion/CurrentLineVerifier.cs
@@ -8,37 +8,23 @@ namespace Anixe.Ion
         public bool IsSectionHeader(ArraySegment<char> currentLine)
         {
             return currentLine.Count != 0
-#if NETSTANDARD2_0
-                && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.HeaderOpeningCharacter;
-#else
-                && currentLine[0] == Consts.IonSpecialChars.HeaderOpeningCharacter;
-#endif
+                && currentLine[0] == Consts.IonSpecialChars.SectionHeaderOpening;
         }
 
         public bool IsTableHeaderRow(ArraySegment<char> currentLine, bool passedCurrentTableHeaderRow)
         {
           return !passedCurrentTableHeaderRow
               && currentLine.Count > 1
-#if NETSTANDARD2_0
-              && ((IList<char>)currentLine)[1] != Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-              && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#else
-              && currentLine[1] != Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-              && currentLine[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#endif
+              && currentLine[1] != Consts.IonSpecialChars.TableHeaderSeparator
+              && currentLine[0] == Consts.IonSpecialChars.TableColumnSeparator;
         }
 
         public bool IsTableDataRow(ArraySegment<char> currentLine, bool passedCurrentTableHeaderRow)
         {
           return passedCurrentTableHeaderRow
               && currentLine.Count > 1
-#if NETSTANDARD2_0
-              && ((IList<char>)currentLine)[1] != Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-              && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#else
-              && currentLine[1] != Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-              && currentLine[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#endif
+              && currentLine[1] != Consts.IonSpecialChars.TableHeaderSeparator
+              && currentLine[0] == Consts.IonSpecialChars.TableColumnSeparator;
         }
 
         public bool IsProperty(ArraySegment<char> currentLine)
@@ -48,47 +34,30 @@ namespace Anixe.Ion
                 return false;
             }
 
-#if NETSTANDARD2_0
-            char firstChar = ((IList<char>)currentLine)[0];
-#else
             char firstChar = currentLine[0];
-#endif
-            return firstChar != Consts.IonSpecialChars.TableOpeningCharacter
-                && firstChar != Consts.IonSpecialChars.HeaderOpeningCharacter
-                && firstChar != Consts.IonSpecialChars.CommentCharacter
+            return firstChar != Consts.IonSpecialChars.TableColumnSeparator
+                && firstChar != Consts.IonSpecialChars.SectionHeaderOpening
+                && firstChar != Consts.IonSpecialChars.BeginCommentLine
                 && !IsWhiteSpace(currentLine);
         }
 
         public bool IsComment(ArraySegment<char> currentLine)
         {
             return currentLine.Count != 0
-#if NETSTANDARD2_0
-                && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.CommentCharacter;
-#else
-                && currentLine[0] == Consts.IonSpecialChars.CommentCharacter;
-#endif
+                && currentLine[0] == Consts.IonSpecialChars.BeginCommentLine;
         }
 
         public bool IsTableRow(ArraySegment<char> currentLine)
         {
             return currentLine.Count != 0
-#if NETSTANDARD2_0
-                && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#else
-                && currentLine[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#endif
+                && currentLine[0] == Consts.IonSpecialChars.TableColumnSeparator;
         }
 
         public bool IsTableHeaderSeparatorRow(ArraySegment<char> currentLine)
         {
             return currentLine.Count > 1
-#if NETSTANDARD2_0
-                && ((IList<char>)currentLine)[1] == Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-                && ((IList<char>)currentLine)[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#else
-                && currentLine[1] == Consts.IonSpecialChars.TableHeaderSeparatorCharacter
-                && currentLine[0] == Consts.IonSpecialChars.TableOpeningCharacter;
-#endif
+                && currentLine[1] == Consts.IonSpecialChars.TableHeaderSeparator
+                && currentLine[0] == Consts.IonSpecialChars.TableColumnSeparator;
         }
 
         public bool IsEmptyLine(ArraySegment<char> currentLine)
@@ -100,11 +69,7 @@ namespace Anixe.Ion
         {
             for (int i = currentLine.Offset; i < currentLine.Count; i++)
             {
-#if NETSTANDARD2_0
-                if (!char.IsWhiteSpace(((IList<char>)currentLine)[i]))
-#else
                 if (!char.IsWhiteSpace(currentLine[i]))
-#endif
                 {
                     return false;
                 }

--- a/Anixe.Ion/Helpers/BufferWriter.cs
+++ b/Anixe.Ion/Helpers/BufferWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Anixe.Ion.Helpers
 {
@@ -9,13 +10,9 @@ namespace Anixe.Ion.Helpers
         private char[]? buffer;
 
         public int Count { get; private set; }
-        public ArraySegment<char> WrittenSegment => this.Count == 0
-#if NETSTANDARD2_0
-            ? new ArraySegment<char>(Array.Empty<char>())
-#else
+        public readonly ArraySegment<char> WrittenSegment => this.Count == 0
             ? ArraySegment<char>.Empty
-#endif
-            : new ArraySegment<char>(this.buffer, 0, this.Count);
+            : new ArraySegment<char>(this.buffer ?? [], 0, this.Count);
 
         public BufferWriter(ArrayPool<char> pool)
         {
@@ -31,6 +28,7 @@ namespace Anixe.Ion.Helpers
           this.Count += charCount;
         }
 
+        [MemberNotNull(nameof(this.buffer))]
         private void EnsureCapacity(int length)
         {
             if (this.buffer != null)

--- a/Anixe.Ion/Helpers/ThrowHelper.cs
+++ b/Anixe.Ion/Helpers/ThrowHelper.cs
@@ -1,18 +1,20 @@
-﻿using Anixe.Ion.Exceptions;
-#if !NETSTANDARD2_0
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#endif
 
 namespace Anixe.Ion.Helpers
 {
     internal static class ThrowHelper
     {
-#if !NETSTANDARD2_0
         [DoesNotReturn]
-#endif
-        public static void Throw_InvalidTableCellDataException()
+        public static void Throw_ArgumentException_UndefinedFilePath()
         {
-            throw new InvalidTableCellDataException("Table cell contains prohibited character");
+            throw new ArgumentException("File path must be defined!");
+        }
+
+        [DoesNotReturn]
+        public static void Throw_ArgumentException_FileDoesNotExists(string filePath)
+        {
+            throw new ArgumentException(string.Format("File '{0}' does not exist!", filePath));
         }
     }
 }

--- a/Anixe.Ion/IIonReader.cs
+++ b/Anixe.Ion/IIonReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Anixe.Ion
 {
@@ -11,6 +12,7 @@ namespace Anixe.Ion
         /// Gets a value indicating whether this instance of <see cref="IIonReader"/> is currently on section header.
         /// </summary>
         /// <value><see langword="true"/> if <see cref="IIonReader.CurrentLine"/> first character is equal to '['; otherwise, <see langword="false"/>.</value>
+        [MemberNotNullWhen(true, nameof(CurrentSection))]
         bool IsSectionHeader { get; }
 
         /// <summary>
@@ -35,7 +37,7 @@ namespace Anixe.Ion
         /// Gets a value indicating whether this instance of <see cref="IIonReader"/> is currently on table row.
         /// </summary>
         /// <value><see langword="true"/> if <see cref="IIonReader.CurrentLine"/> first character is equal to '|'; otherwise, <see langword="false"/>.</value>
-        bool IsTableRow { get;}
+        bool IsTableRow { get; }
 
         /// <summary>
         /// Gets a value indicating whether this instance of <see cref="IIonReader"/> is currently on table header separator row. IMPORTANT: we recognize this
@@ -87,4 +89,3 @@ namespace Anixe.Ion
         bool Read();
     }
 }
-

--- a/Anixe.Ion/IIonWriter.cs
+++ b/Anixe.Ion/IIonWriter.cs
@@ -14,7 +14,9 @@ namespace Anixe.Ion
         void WriteProperty(string name, Action<TextWriter> writeValueAction);
 
         void WriteTableHeader(params string[] columns);
+        void WriteTableHeader(params ReadOnlySpan<string> columns);
         void WriteTableRow(params string[] data);
+        void WriteTableRow(params ReadOnlySpan<string> data);
         void WriteTableCell(Action<TextWriter> writeCellAction, bool lastCellInRow = false);
         void WriteTableCell<TContext>(TContext context, Action<TextWriter, TContext> writeCellAction, bool lastCellInRow = false);
 
@@ -24,15 +26,13 @@ namespace Anixe.Ion
         void WriteTableCell(int value, bool lastCellInRow = false);
 
         /// <summary>Writes table cell value and adds table separators when needed.</summary>
-        /// <param name="value">Value to write. Cannot contain prohibited characters '\n' and '|'</param>
+        /// <param name="value">Value to write.</param>
         /// <param name="lastCellInRow">Adds new line character when is set to <see langword="true"/></param>
-        /// <exception cref="Anixe.Ion.Exceptions.InvalidTableCellDataException">Value contains '\n' or '|' character</exception>>
         void WriteTableCell(string? value, bool lastCellInRow = false);
 
         /// <summary>Writes table cell value and adds table separators when needed.</summary>
-        /// <param name="value">Value to write. Cannot is one of prohibited characters '\n' and '|'</param>
+        /// <param name="value">Value to write.</param>
         /// <param name="lastCellInRow">Adds new line character when is set to <see langword="true"/></param>
-        /// <exception cref="Anixe.Ion.Exceptions.InvalidTableCellDataException">Value is '\n' or '|' character</exception>>
         void WriteTableCell(char value, bool lastCellInRow = false);
 
         /// <summary>Writes table cell value and adds table separators when needed.</summary>
@@ -56,13 +56,21 @@ namespace Anixe.Ion
         void WriteTableCell(bool value, bool lastCellInRow = false);
 
         /// <summary>Writes table cell value and adds table separators when needed.</summary>
-        /// <param name="buffer">The character array to write data from. Cannot contain prohibited characters '\n' and '|'</param>
+        /// <param name="buffer">The character array to write data from.</param>
         /// <param name="index">The character position in the buffer at which to start retrieving data.</param>
         /// <param name="count">The number of characters to write.</param>
         /// <param name="lastCellInRow">Adds new line character when is set to <see langword="true"/></param>
-        /// <exception cref="Anixe.Ion.Exceptions.InvalidTableCellDataException">Buffer contains '\n' or '|' character</exception>>
         void WriteTableCell(char[] buffer, int index, int count, bool lastCellInRow = false);
+
+        /// <summary>
+        /// Writes table cell value and adds table separators when needed.
+        /// </summary>
+        /// <param name="span">The span of characters to write data from.</param>
+        /// <param name="lastCellInRow">Adds new line character when is set to <see langword="true"/></param>
+        void WriteTableCell(ReadOnlySpan<char> span, bool lastCellInRow = false);
+
         void WriteEmptyLine();
+
         void Flush();
     }
 }

--- a/Anixe.Ion/IonExtensions.cs
+++ b/Anixe.Ion/IonExtensions.cs
@@ -15,5 +15,22 @@ namespace Anixe.Ion
     {
       return new IonProperty(reader, propertySeparator);
     }
+
+    /// <summary>
+    /// Creates ref-struct that allows reading table row cells in an efficient way.
+    /// It does not advance the reader to the next line.
+    /// </summary>
+    /// <param name="reader">Instance of <see cref="IIonReader"/>.</param>
+    /// <returns>A new instance of <see cref="TableRowReader"/>.</returns>
+    /// <exception cref="InvalidOperationException">Current line is not a table row.</exception>
+    public static TableRowReader ReadTableRow(this IIonReader reader)
+    {
+      if (!reader.IsTableRow)
+      {
+        throw new InvalidOperationException("Cannot read table row when reader is not on table row line.");
+      }
+
+      return new TableRowReader(reader.CurrentRawLine);
+    }
   }
 }

--- a/Anixe.Ion/IonReader.cs
+++ b/Anixe.Ion/IonReader.cs
@@ -1,6 +1,7 @@
 ﻿using Anixe.Ion.Helpers;
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -26,15 +27,15 @@ namespace Anixe.Ion
         private readonly Encoding enc = Encoding.UTF8;
         private bool checkBOM;
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="IonReader"/>.
-    /// </summary>
-    /// <param name="stream">Stream to read from</param>
-    /// <param name="currentLineVerifier">Object which verifies state based on current line.</param>
-    /// <param name="sectionHeaderReader">Object which reads sections.</param>
-    /// <param name="leaveOpen"><see langword="true"/> if the stream should be open after <see cref="Dispose()"/>.</param>
-    /// <param name="charPool">Provide own <see cref="ArrayPool{T}.Shared"/> instance. If <see langword="null"/> then <see cref="ArrayPool{T}.Shared"/> is used.</param>
-    public IonReader(Stream stream, CurrentLineVerifier currentLineVerifier, SectionHeaderReader sectionHeaderReader, bool leaveOpen, ArrayPool<char>? charPool = null)
+        /// <summary>
+        /// Initializes a new instance of <see cref="IonReader"/>.
+        /// </summary>
+        /// <param name="stream">Stream to read from</param>
+        /// <param name="currentLineVerifier">Object which verifies state based on current line.</param>
+        /// <param name="sectionHeaderReader">Object which reads sections.</param>
+        /// <param name="leaveOpen"><see langword="true"/> if the stream should be open after <see cref="Dispose()"/>.</param>
+        /// <param name="charPool">Provide own <see cref="ArrayPool{T}.Shared"/> instance. If <see langword="null"/> then <see cref="ArrayPool{T}.Shared"/> is used.</param>
+        public IonReader(Stream stream, CurrentLineVerifier currentLineVerifier, SectionHeaderReader sectionHeaderReader, bool leaveOpen, ArrayPool<char>? charPool = null)
         {
             this.stream = stream;
             this.disposed = false;
@@ -51,6 +52,7 @@ namespace Anixe.Ion
 
         #region IIonReader members
 
+        [MemberNotNullWhen(true, nameof(CurrentSection))]
         public bool IsSectionHeader => this.currentLineVerifier.IsSectionHeader(CurrentRawLine);
 
         public bool IsProperty => this.currentLineVerifier.IsProperty(CurrentRawLine);
@@ -67,7 +69,7 @@ namespace Anixe.Ion
 
         public bool IsEmptyLine => this.currentLineVerifier.IsEmptyLine(CurrentRawLine);
 
-        public string CurrentLine => new string(CurrentRawLine.Array, CurrentRawLine.Offset, CurrentRawLine.Count);
+        public string CurrentLine => new string(CurrentRawLine.Array!, CurrentRawLine.Offset, CurrentRawLine.Count);
 
         public ArraySegment<char> CurrentRawLine { get; private set; }
 
@@ -105,7 +107,7 @@ namespace Anixe.Ion
             if(IsSectionHeader)
             {
                 ArraySegment<char> headerSegment = this.sectionHeaderReader.Read(CurrentRawLine);
-                CurrentSection = new string(headerSegment.Array, headerSegment.Offset, headerSegment.Count);
+                CurrentSection = new string(headerSegment.Array!, headerSegment.Offset, headerSegment.Count);
             }
 
             if(passedCurrentTableHeaderRow)

--- a/Anixe.Ion/IonReaderFactory.cs
+++ b/Anixe.Ion/IonReaderFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Anixe.Ion.Helpers;
+using System;
 using System.Buffers;
 using System.IO;
 
@@ -47,18 +48,17 @@ namespace Anixe.Ion
 
         private static void ValidateFilePath(string filePath)
         {
-            if(string.IsNullOrWhiteSpace(filePath))
+            if (string.IsNullOrWhiteSpace(filePath))
             {
-                throw new ArgumentException(Consts.ErrorMessages.UndefinedFilePath);
+                ThrowHelper.Throw_ArgumentException_UndefinedFilePath();
             }
 
-            if(!File.Exists(filePath))
+            if (!File.Exists(filePath))
             {
-                throw new ArgumentException(string.Format(Consts.ErrorMessages.FileDoesNotExist, filePath));
+                ThrowHelper.Throw_ArgumentException_FileDoesNotExists(filePath);
             }
         }
 
         #endregion
     }
 }
-

--- a/Anixe.Ion/IonWriterFactory.cs
+++ b/Anixe.Ion/IonWriterFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Anixe.Ion.Helpers;
+using System;
 using System.IO;
 
 namespace Anixe.Ion
@@ -67,18 +68,17 @@ namespace Anixe.Ion
 
         private static void ValidateFilePath(string filePath)
         {
-            if(string.IsNullOrWhiteSpace(filePath))
+            if (string.IsNullOrWhiteSpace(filePath))
             {
-                throw new ArgumentException(Consts.ErrorMessages.UndefinedFilePath);
+                ThrowHelper.Throw_ArgumentException_UndefinedFilePath();
             }
 
-            if(!File.Exists(filePath))
+            if (!File.Exists(filePath))
             {
-                throw new ArgumentException(string.Format(Consts.ErrorMessages.FileDoesNotExist, filePath));
+                ThrowHelper.Throw_ArgumentException_FileDoesNotExists(filePath);
             }
         }
 
         #endregion
     }
 }
-

--- a/Anixe.Ion/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Anixe.Ion/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net9.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>

--- a/Anixe.Ion/SectionHeaderReader.cs
+++ b/Anixe.Ion/SectionHeaderReader.cs
@@ -6,11 +6,16 @@ namespace Anixe.Ion
     {
         public ArraySegment<char> Read(ArraySegment<char> currentLine)
         {
-            var indexOfOpeningCharacter = Array.IndexOf(currentLine.Array, Consts.IonSpecialChars.HeaderOpeningCharacter, currentLine.Offset);
-            var indexOfClosingCharacter = Array.IndexOf(currentLine.Array, Consts.IonSpecialChars.HeaderClosingCharacter, indexOfOpeningCharacter + 1);
+            var array = currentLine.Array!;
+            var indexOfOpeningCharacter = Array.IndexOf(array, Consts.IonSpecialChars.SectionHeaderOpening, currentLine.Offset);
+            var indexOfClosingCharacter = Array.IndexOf(array, Consts.IonSpecialChars.SectionHeaderClosing, indexOfOpeningCharacter + 1);
 
-            return new ArraySegment<char>(currentLine.Array, indexOfOpeningCharacter + 1, indexOfClosingCharacter - indexOfOpeningCharacter - 1);
+            if (indexOfOpeningCharacter < 0 || indexOfClosingCharacter < 0)
+            {
+                throw new InvalidOperationException("Invalid section header format.");
+            }
+
+            return new ArraySegment<char>(array, indexOfOpeningCharacter + 1, indexOfClosingCharacter - indexOfOpeningCharacter - 1);
         }
     }
 }
-

--- a/Anixe.Ion/TableRowReader.cs
+++ b/Anixe.Ion/TableRowReader.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Buffers;
+
+namespace Anixe.Ion;
+
+public ref struct TableRowReader
+{
+    private static readonly SearchValues<string> EscapedCharacters = SearchValues.Create(["\\n", "\\|"], StringComparison.Ordinal);
+    private ReadOnlySpan<char> span;
+
+    internal TableRowReader(ReadOnlySpan<char> rawTableLine)
+    {
+        // remove trailing line endings, tabs and other whitespaces from the end
+        var trimmedLine = rawTableLine.TrimEnd();
+
+        if (!trimmedLine.StartsWith('|') || !trimmedLine.EndsWith('|'))
+        {
+            Throw_FormatException();
+        }
+
+        // trim pipes from start and end
+        trimmedLine = trimmedLine[1..^1];
+
+        this.span = trimmedLine.Trim(' ');
+
+        static void Throw_FormatException() =>
+            throw new FormatException("Table row must start and end with a pipe character '|'.");
+    }
+
+    private ReadOnlySpan<char> CurrentRawValue { get; set; }
+
+    /// <summary>
+    /// Reads the next table cell value from the current line.
+    /// It unescapes escaped characters `\n` and `\|`.
+    /// </summary>
+    /// <returns>A span that represents value from cell.</returns>
+    /// <exception cref="InvalidOperationException">No more elements to read.</exception>
+    public ReadOnlySpan<char> ReadNext()
+    {
+        if (!MoveNext())
+        {
+            Throw_NoMoreElementsToRead();
+        }
+
+        if (NeedsUnescape(this.CurrentRawValue))
+        {
+            return Unescape(this.CurrentRawValue).Trim(' ');
+        }
+
+        return this.CurrentRawValue.Trim(' ');
+
+        static bool NeedsUnescape(ReadOnlySpan<char> rawValue) =>
+            rawValue.ContainsAny(EscapedCharacters);
+
+        static void Throw_NoMoreElementsToRead() =>
+            throw new InvalidOperationException("No more elements to read.");
+    }
+
+    // Unescapes special sequences in a table cell value, such as '\n' to newline and '\|' to '|'
+    private static ReadOnlySpan<char> Unescape(ReadOnlySpan<char> rawValue)
+    {
+        int len = rawValue.Length;
+        Span<char> buffer = len <= 256 ? stackalloc char[len] : new char[len];
+        int outIdx = 0;
+
+        for (int i = 0; i < len;)
+        {
+            // Check for escape sequence starting with backslash
+            if (rawValue[i] == '\\' && i + 1 < len)
+            {
+                char next = rawValue[i + 1];
+                if (next == '|')
+                {
+                    // Replace '\|' with '|'
+                    buffer[outIdx++] = '|';
+                    i += 2;
+                    continue;
+                }
+                else if (next == 'n')
+                {
+                    // Replace '\n' with newline character
+                    buffer[outIdx++] = '\n';
+                    i += 2;
+                    continue;
+                }
+            }
+            // Copy character as-is if not part of an escape sequence
+            buffer[outIdx++] = rawValue[i++];
+        }
+
+        return buffer.Slice(0, outIdx).ToString();
+    }
+
+    private bool MoveNext()
+    {
+        if (this.span.IsEmpty)
+        {
+#pragma warning disable CA2265 // Do not compare Span<T> to 'null' or 'default'
+            if (this.span == default)
+            {
+                return false;
+            }
+#pragma warning restore CA2265
+
+            this.CurrentRawValue = this.span;
+            this.span = default;
+            return true;
+        }
+
+        // Hot path: no escaping present, just split on '|'
+        int delimiterIdx = this.span.IndexOf('|');
+        if (delimiterIdx >= 0 && !HasAnyBackslash(this.span.Slice(0, delimiterIdx)))
+        {
+            this.CurrentRawValue = this.span.Slice(0, delimiterIdx);
+            this.span = this.span.Slice(delimiterIdx + 1);
+            return true;
+        }
+
+        if (delimiterIdx == -1 && !HasAnyBackslash(this.span))
+        {
+            this.CurrentRawValue = this.span;
+            this.span = default;
+            return true;
+        }
+
+        // Fallback: slow path with escape handling
+        ExtractEscapedSegment();
+        return true;
+
+        static bool HasAnyBackslash(ReadOnlySpan<char> span)
+        {
+            return span.IndexOf('\\') >= 0;
+        }
+    }
+
+    private void ExtractEscapedSegment()
+    {
+        int delimiterIdx = -1; // Index of the next unescaped pipe delimiter
+        int i = 0;
+        // Iterate through the span to find the next unescaped '|'
+        while (i < this.span.Length)
+        {
+            // Find the next '|' character from the current position
+            int nextIdx = this.span.Slice(i).IndexOf('|');
+            if (nextIdx == -1)
+            {
+                // No more '|' found, break out of the loop
+                break;
+            }
+            int candidateIdx = i + nextIdx;
+            int backslashCount = 0;
+            int j = candidateIdx - 1;
+            // Count consecutive backslashes before the '|' to determine if it's escaped
+            while (j >= 0 && this.span[j] == '\\')
+            {
+                backslashCount++;
+                j--;
+            }
+            // If the number of backslashes is even, the '|' is not escaped
+            if (backslashCount % 2 == 0)
+            {
+                delimiterIdx = candidateIdx;
+                break;
+            }
+            // Move past the escaped '|' and continue searching
+            i = candidateIdx + 1;
+        }
+
+        if (delimiterIdx < 0)
+        {
+            // No unescaped '|' found, take the rest of the span as the value
+            this.CurrentRawValue = this.span;
+            this.span = default;
+        }
+        else
+        {
+            // Extract the segment up to the unescaped '|' and advance the span
+            this.CurrentRawValue = this.span.Slice(0, delimiterIdx);
+            this.span = this.span.Slice(delimiterIdx + 1);
+        }
+    }
+}

--- a/Anixe.Ion/WriterOptions.cs
+++ b/Anixe.Ion/WriterOptions.cs
@@ -9,13 +9,13 @@ namespace Anixe.Ion
 
         /// <summary>
         /// Use this option if <see cref="IIonWriter"/> serializes ion content as a part of other document in different format.
-        /// Eg. ion formatted value is a part of json's property value.
+        /// E.g. ion formatted value is a part of json's property value.
         /// </summary>
         public bool EscapeQuotes { get; set; }
 
         /// <summary>
         /// Use this option if <see cref="IIonWriter"/> serializes ion content as a part of other document in different format.
-        /// Eg. ion formatted value is a part of json's property value.
+        /// E.g. ion formatted value is a part of json's property value.
         /// </summary>
         public bool EscapeNewLineChars { get; set; }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Anixe.Ion CHANGELOG
 
+## 3.0.0
+- Drop support of .NET below .NET 9
+- Add method ReadTableRow() that returns reader for row cells and unescapes them if needed
+- Change behavior of WriteTableRow() that previously thrown exception for '|' and newline charcter. Now it escapes them with \| and \n.
+- Add metadata to the Nuget package
+- various small performance improvements
+- add missing nullable annotations MemberNotNullWhen
+- change some exceptions to use standard .NET messages instead of custom ones
+- change testing library from NUnit to xUnit
+
 ## 2.1.1
 - added build for .NET Standard 2.0
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # IonReader
 
 ## Introduction
-Anixe.Ion library is a netstandard2.1 library that provides reader with fast, non-cached, forward only access to *.ion files and writer to build ion file content. 
+Anixe.Ion library is a .NET library that provides reader with fast, non-cached, forward only access to *.ion files and writer to build ion file content. 
 
 ## Features
-#### IonReaderFactory
+### IonReaderFactory
 Anixe.Ion library provides static factory which can create an instance for **IonReader** interface. Factory enables two ways of creation the **IonReader** instance:
 
 1. With path to the file. File is opened with: **FileMode.Open**, **FileAccess.Read**, **FileShare.ReadWrite**. Possible argument exceptions:
@@ -39,7 +39,7 @@ Anixe.Ion library provides static factory which can create an instance for **Ion
 * **Read** the main method of the class, it reads the stream provided by IonReader and fires an event for each section
 
 ## Example use
-#### With file path
+### With file path
 ```c#
 class MainClass
 {
@@ -60,7 +60,7 @@ class MainClass
     }
 }
 ```
-#### With stream
+### With stream
 ```c#
 class MainClass
 {
@@ -85,7 +85,7 @@ class MainClass
 }
 ```
 
-#### With SectionReader
+### With SectionReader
 ```c#
 class MainClass
 {
@@ -110,58 +110,4 @@ class MainClass
         sectionReader.Read();
     }
 }
-```
-
-### Benchmarks history
-
-To run benchmark use the Anixe.Ion.Benchmark project
-
-```
-cd Anixe.Ion.Benchmark
-dotnet run -c Release
-```
-
-The output of reading stations.ion:
-
-* baseline
-
-```
- Method |     Mean |     Error |    StdDev | Allocated |
-------- |---------:|----------:|----------:|----------:|
-   Read | 43.30 ms | 0.8562 ms | 0.8009 ms |   7.26 KB |
-```
-
-* added UT8 encoding, which requires additional bufffers
-```
-Method |     Mean |     Error |    StdDev | Allocated |
-------- |---------:|----------:|----------:|----------:|
-   Read | 60.19 ms | 0.3408 ms | 0.3188 ms |   9.67 KB |
-```
-
-* increase read buffer size to 1024 bytes
-```
- Method |     Mean |     Error |    StdDev | Allocated |
-------- |---------:|----------:|----------:|----------:|
-   Read | 30.86 ms | 0.4422 ms | 0.3920 ms |  14.35 KB |
-```
-
-* append StringBuilder instance with char array block instead of char by char
-```
- Method |     Mean |     Error |    StdDev | Allocated |
-------- |---------:|----------:|----------:|----------:|
-   Read | 20.84 ms | 0.0839 ms | 0.0744 ms |  14.94 KB |
-```
-
-* remove Array.Clear which was not required because of using index & count on feeding StringBuilder instance.
-```
- Method |     Mean |     Error |    StdDev | Allocated |
-------- |---------:|----------:|----------:|----------:|
-   Read | 9.432 ms | 0.0468 ms | 0.0438 ms |  14.92 KB |
-```
-
-Use custom struct BufferWriter instaed of StringBuilder
-```
-| Method |     Mean |     Error |    StdDev | Allocated |
-|------- |---------:|----------:|----------:|----------:|
-|   Read | 5.867 ms | 0.0281 ms | 0.0235 ms |   4.59 KB |
 ```


### PR DESCRIPTION
## CHANGELOG 3.0.0
- Drop support of .NET below .NET 9
- Add method ReadTableRow() that returns reader for row cells and unescapes them if needed
- Change behavior of WriteTableRow() that previously thrown exception for '|' and newline charcter. Now it escapes them with `\|` and `\n`.
- Add metadata to the Nuget package
- various small performance improvements
- add missing nullable annotations MemberNotNullWhen
- change some exceptions to use standard .NET messages instead of custom ones
- change testing library from NUnit to xUnit