### PR TITLE
Release v3.0.1

### DIFF
--- a/Anixe.Ion.UnitTests/IonReaderTest.cs
+++ b/Anixe.Ion.UnitTests/IonReaderTest.cs
@@ -128,12 +128,12 @@ namespace Anixe.Ion.UnitTests
         [Fact]
         public void Should_Read_Table_Cell()
         {
-            //Assert.Equal("", ReadTableCell(""));
-            //Assert.Equal("x", ReadTableCell("x"));
-            //Assert.Equal("\\a", ReadTableCell("\\a"));
-            //Assert.Equal("\n", ReadTableCell("\\n"));
+            Assert.Equal("", ReadTableCell(""));
+            Assert.Equal("x", ReadTableCell("x"));
+            Assert.Equal("\\a", ReadTableCell("\\a"));
+            Assert.Equal("\n", ReadTableCell("\\n"));
             Assert.Equal("|", ReadTableCell("\\|"));
-            //Assert.Equal("Berlin Mitte Kronenstraße", ReadTableCell("Berlin Mitte Kronenstraße"));
+            Assert.Equal("Berlin Mitte Kronenstraße", ReadTableCell("Berlin Mitte Kronenstraße"));
             static string ReadTableCell(string ionCellContent)
             {
                 var ion = $"""
@@ -151,7 +151,7 @@ namespace Anixe.Ion.UnitTests
                         if (reader.IsTableDataRow)
                         {
                             var rowReader = reader.ReadTableRow();
-                            return rowReader.ReadNext().ToString();
+                            return rowReader.ReadNextString();
                         }
                     }
                 }
@@ -163,7 +163,7 @@ namespace Anixe.Ion.UnitTests
         [Fact]
         public void ReadTableCellTest()
         {
-            var ion = """
+            const string ion = """
                 [TABLE]
                 | col1 | col2 | col3 | col4|
                 |--------|-|-----|----|
@@ -178,13 +178,13 @@ namespace Anixe.Ion.UnitTests
                     if (reader.IsTableDataRow)
                     {
                         var rowReader = reader.ReadTableRow();
-                        Assert.Equal("a", rowReader.ReadNext().ToString());
-                        Assert.Equal("b", rowReader.ReadNext().ToString());
-                        Assert.Equal("\ntext| separated", rowReader.ReadNext().ToString());
-                        Assert.Equal("", rowReader.ReadNext().ToString());
+                        Assert.Equal("a", rowReader.ReadNextString());
+                        Assert.Equal("b", rowReader.ReadNextSpan().ToString());
+                        Assert.Equal("\ntext| separated", rowReader.ReadNextString());
+                        Assert.Equal("", rowReader.ReadNextString());
                         try
                         {
-                            rowReader.ReadNext();
+                            rowReader.ReadNextSpan();
                             Assert.Fail("Should not be reached because an exception should be thrown.");
                         }
                         catch (InvalidOperationException)

--- a/Anixe.Ion.UnitTests/IonWriterTests.cs
+++ b/Anixe.Ion.UnitTests/IonWriterTests.cs
@@ -242,6 +242,40 @@ namespace Anixe.Ion.UnitTests
         }
 
         [Fact]
+        public void IIonWriter_WriteTableCell()
+        {
+            // string overload
+            Assert.Equal("| x |", WriteTableCell(tw => tw.WriteTableCell("x")));
+
+            // bool overload
+            Assert.Equal("| True |", WriteTableCell(tw => tw.WriteTableCell(true)));
+
+            // int overload
+            Assert.Equal("| 1 |", WriteTableCell(tw => tw.WriteTableCell(1)));
+
+            // long overload
+            Assert.Equal("| 1 |", WriteTableCell(tw => tw.WriteTableCell(1L)));
+
+            // double overload
+            Assert.Equal("| 1.1 |", WriteTableCell(tw => tw.WriteTableCell(1.1)));
+            Assert.Equal("| 1 |", WriteTableCell(tw => tw.WriteTableCell(1.0)));
+
+            // decimal overload
+            Assert.Equal("| 1.1 |", WriteTableCell(tw => tw.WriteTableCell(1.1m)));
+            Assert.Equal("| 1.0 |", WriteTableCell(tw => tw.WriteTableCell(1.0m)));
+
+            static string WriteTableCell(Action<IIonWriter> action)
+            {
+                var sb = new StringBuilder();
+                using (var subject = new IonWriter(new StringWriter(sb)))
+                {
+                    action(subject);
+                }
+                return sb.ToString();
+            }
+        }
+
+        [Fact]
         public void IIonWriter_WriteTableRow_Escapes()
         {
             var sb = new StringBuilder();

--- a/Anixe.Ion/Anixe.Ion.csproj
+++ b/Anixe.Ion/Anixe.Ion.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Anixe.Ion/IonWriter.cs
+++ b/Anixe.Ion/IonWriter.cs
@@ -27,6 +27,7 @@ namespace Anixe.Ion
         : this(tw, new WriterOptions())
         {
         }
+
         internal WriterState State => this.state;
 
         #region IIonWriter Members
@@ -241,7 +242,7 @@ namespace Anixe.Ion
         public void WriteTableCell(int value, bool lastCellInRow = false)
         {
             WriteTableCellBefore();
-            tw.Write(value);
+            tw.Write(value.ToString(CultureInfo.InvariantCulture));
             WriteTableCellAfter(lastCellInRow);
         }
 
@@ -262,21 +263,21 @@ namespace Anixe.Ion
         public void WriteTableCell(double value, bool lastCellInRow = false)
         {
             WriteTableCellBefore();
-            tw.Write(value);
+            tw.Write(value.ToString(CultureInfo.InvariantCulture));
             WriteTableCellAfter(lastCellInRow);
         }
 
         public void WriteTableCell(decimal value, bool lastCellInRow = false)
         {
             WriteTableCellBefore();
-            tw.Write(value);
+            tw.Write(value.ToString(CultureInfo.InvariantCulture));
             WriteTableCellAfter(lastCellInRow);
         }
 
         public void WriteTableCell(long value, bool lastCellInRow = false)
         {
             WriteTableCellBefore();
-            tw.Write(value);
+            tw.Write(value.ToString(CultureInfo.InvariantCulture));
             WriteTableCellAfter(lastCellInRow);
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Anixe.Ion CHANGELOG
 
+## 3.0.1
+- Rename TableRowReader.ReadNext() to ReadNextSpan()
+- Add ReadNextString() method to TableRowReader
+- Trim tab characters when reading table row cells
+- Use always InvariantCulture for writing numbers into table cells
+- Add property CanReadNext to TableRowReader to check if there are more cells in the row to be read
+
 ## 3.0.0
 - Drop support of .NET below .NET 9
 - Add method ReadTableRow() that returns reader for row cells and unescapes them if needed
-- Change behavior of WriteTableRow() that previously thrown exception for '|' and newline charcter. Now it escapes them with \| and \n.
+- Change behavior of WriteTableRow() that previously thrown exception for '|' and newline character. Now it escapes them with \| and \n.
 - Add metadata to the Nuget package
 - various small performance improvements
 - add missing nullable annotations MemberNotNullWhen


### PR DESCRIPTION
## CHANGELOG 3.0.1
- Rename TableRowReader.ReadNext() to ReadNextSpan()
- Add ReadNextString() method to TableRowReader
- Trim tab characters when reading table row cells
- Use always InvariantCulture for writing numbers into table cells
- Add property CanReadNext to TableRowReader to check if there are more cells in the row to be read